### PR TITLE
Supporting detection of regular image links

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -20,9 +20,10 @@ var MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
 // e.g. ![](web+graphie://ka-perseus-graphie.s3.amazonaws.com/542f2b4e297910eed545a5c29c3866918655bab4)
 var GRAPHIE_REGEX = /\!\[\]\([^)]+\)/g;
 
-// Matches image link strings,
-// e.g. 'https://ka-perseus-graphie.s3.amazonaws.com/e75c49cb5753492629016169933ab63af3b9f122.png
-var IMAGE_REGEX = /https:\/\/[^\s]+\.png/g;
+// Matches pure image and graphie link strings,
+// e.g. https://ka-perseus-graphie.s3.amazonaws.com/e75c49cb5753492629016169933ab63af3b9f122.png
+// or web+graphie://ka-perseus-graphie.s3.amazonaws.com/542f2b4e297910eed545a5c29c3866918655bab4
+var IMAGE_REGEX = /https:[^\s]+\.png|web\+graphie:[a-z0-9\.\-/]+(?=[\s,]|$)/g;
 
 // Matches widget strings, e.g. [[☃ Expression 1]]
 var WIDGET_REGEX = /\[\[[\u2603][^\]]+\]\]/g;
@@ -582,7 +583,8 @@ var TranslationAssistant = (function () {
                 var normalObj = JSON.parse(normalStr);
 
                 // Translate items that are only math, a graphie, an image, or a
-                // widget. TODO(kevinb) handle multiple non-nl_text items
+                // widget.
+                // TODO(kevinb) handle multiple non-nl_text items
                 if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
                     if (normalObj.str === '__MATH__') {
                         // Only translate the math if it doesn't include any

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -8,6 +8,10 @@
 // $\text{cost} = \$4$
 'use strict';
 
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
@@ -15,6 +19,10 @@ var MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
 // Matches graphie strings,
 // e.g. ![](web+graphie://ka-perseus-graphie.s3.amazonaws.com/542f2b4e297910eed545a5c29c3866918655bab4)
 var GRAPHIE_REGEX = /\!\[\]\([^)]+\)/g;
+
+// Matches image link strings,
+// e.g. 'https://ka-perseus-graphie.s3.amazonaws.com/e75c49cb5753492629016169933ab63af3b9f122.png
+var IMAGE_REGEX = /https:\/\/[^\s]+\.png/g;
 
 // Matches widget strings, e.g. [[☃ Expression 1]]
 var WIDGET_REGEX = /\[\[[\u2603][^\]]+\]\]/g;
@@ -36,8 +44,8 @@ var LINE_BREAK = '\n\n';
  * The key string is a JSON string that looks like:
  * '{str:"Is __MATH__ equal to __MATH__",texts:[["red", "blue"],[]]}'
  *
- * The `str` property is the `str` parameter with math, graphies, and widgets
- * replaced with placeholders.  Also, we remove unimportant whitespace
+ * The `str` property is the `str` parameter with math, graphies, images, and
+ * widgets replaced with placeholders.  Also, we remove unimportant whitespace
  * differences on the item so that we can group strings with similar natural
  * language text.  We also disregard bold markup when determining a match.
  * This means that translators may have to add bold markup to the suggestion
@@ -74,7 +82,7 @@ function stringToGroupKey(str) {
         return result;
     });
 
-    str = str.replace(MATH_REGEX, '__MATH__').replace(GRAPHIE_REGEX, '__GRAPHIE__').replace(WIDGET_REGEX, '__WIDGET__').replace(/__MATH__[\t ]*__WIDGET__/g, '__MATH__ __WIDGET__').split(LINE_BREAK).map(function (line) {
+    str = str.replace(MATH_REGEX, '__MATH__').replace(GRAPHIE_REGEX, '__GRAPHIE__').replace(IMAGE_REGEX, '__IMAGE__').replace(WIDGET_REGEX, '__WIDGET__').replace(/__MATH__[\t ]*__WIDGET__/g, '__MATH__ __WIDGET__').split(LINE_BREAK).map(function (line) {
         return line.trim();
     }).join(LINE_BREAK);
 
@@ -104,8 +112,9 @@ function stringToGroupKey(str) {
  * @param {String} englishStr The English source string.
  * @param {String} translatedStr The translation of the englishStr.
  * @param {String} lang ka_locale of translatedStr.
- * @param {RegExp} findRegex A regex that matches math, graphies, or widgets.
- *        Use one of MATH_REGEX, GRAPHIE_REGEX, or WIDGET_REGEX.
+ * @param {RegExp} findRegex A regex that matches math, graphies, images, or
+ *        widgets. Use one of MATH_REGEX, GRAPHIE_REGEX, IMAGE_REGEX, or
+ *        WIDGET_REGEX.
  * @param {Object} [mathDictionary] English to translated string mapping for
  *        for strings inside \text{} and \textbf{} blocks.
  * @returns {Array} An array representing the mapping.
@@ -135,10 +144,12 @@ mathDictionary) {
                 throw new Error('math doesn\'t match');
             } else if (findRegex === GRAPHIE_REGEX) {
                 throw new Error('graphies don\'t match');
+            } else if (findRegex === IMAGE_REGEX) {
+                throw new Error('image links don\'t match');
             } else if (findRegex === WIDGET_REGEX) {
                 throw new Error('widgets don\'t match');
             } else {
-                throw new Error('the only acceptable values for getFunc are ' + 'getMaths, getGraphies, and getWdigets');
+                throw new Error('the only acceptable values for getFunc are ' + 'getMaths, getGraphies, getImages, and getWdigets');
             }
         }
         mapping[outputIndex] = inputIndex;
@@ -204,9 +215,11 @@ function getMathDictionary(englishStr, translatedStr) {
     inputs.forEach(function (input) {
         var normalized = input;
 
-        replaceRegexes.forEach(function (_ref3) {
-            var regex = _ref3[0];
-            var str = _ref3[1];
+        replaceRegexes.forEach(function (_ref) {
+            var _ref2 = _slicedToArray(_ref, 2);
+
+            var regex = _ref2[0];
+            var str = _ref2[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -220,9 +233,11 @@ function getMathDictionary(englishStr, translatedStr) {
     outputs.forEach(function (output) {
         var normalized = output;
 
-        replaceRegexes.forEach(function (_ref4) {
-            var regex = _ref4[0];
-            var str = _ref4[1];
+        replaceRegexes.forEach(function (_ref3) {
+            var _ref32 = _slicedToArray(_ref3, 2);
+
+            var regex = _ref32[0];
+            var str = _ref32[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -238,9 +253,11 @@ function getMathDictionary(englishStr, translatedStr) {
     var matchRegexes = [[/__TEXT__/, TEXT_REGEX], [/__TEXTBF__/, TEXTBF_REGEX]];
 
     Object.keys(inputMap).forEach(function (key) {
-        matchRegexes.forEach(function (_ref5) {
-            var match = _ref5[0];
-            var regex = _ref5[1];
+        matchRegexes.forEach(function (_ref4) {
+            var _ref42 = _slicedToArray(_ref4, 2);
+
+            var match = _ref42[0];
+            var regex = _ref42[1];
 
             if (match.test(key)) {
                 var _ret = (function () {
@@ -315,7 +332,7 @@ function createTemplate(englishStr, translatedStr, lang) {
     try {
         return {
             lines: translatedLines.map(function (line) {
-                return line.replace(MATH_REGEX, '__MATH__').replace(GRAPHIE_REGEX, '__GRAPHIE__').replace(WIDGET_REGEX, '__WIDGET__');
+                return line.replace(MATH_REGEX, '__MATH__').replace(GRAPHIE_REGEX, '__GRAPHIE__').replace(IMAGE_REGEX, '__IMAGE__').replace(WIDGET_REGEX, '__WIDGET__');
             }),
             mathMapping: {
                 englishToTranslated: getMapping(englishStr, translatedStr, lang, MATH_REGEX, translatedDictionary),
@@ -325,6 +342,7 @@ function createTemplate(englishStr, translatedStr, lang) {
                 englishToEnglish: getMapping(englishStr, englishStr, 'en', MATH_REGEX, englishDictionary)
             },
             graphieMapping: getMapping(englishStr, translatedStr, lang, GRAPHIE_REGEX),
+            imageMapping: getMapping(englishStr, translatedStr, lang, IMAGE_REGEX),
             widgetMapping: getMapping(englishStr, translatedStr, lang, WIDGET_REGEX),
             mathDictionary: translatedDictionary
         };
@@ -376,34 +394,43 @@ function replaceTextInMath(englishMath, dict) {
 
     var textCommands = ['text', 'textbf'];
 
-    var _loop = function () {
-        if (_isArray) {
-            if (_i >= _iterator.length) return 'break';
-            _ref = _iterator[_i++];
-        } else {
-            _i = _iterator.next();
-            if (_i.done) return 'break';
-            _ref = _i.value;
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+        var _loop = function () {
+            var _step$value = _slicedToArray(_step.value, 2);
+
+            var englishText = _step$value[0];
+            var translatedText = _step$value[1];
+
+            textCommands.forEach(function (cmd) {
+                var regex = new RegExp('\\\\' + cmd + '(\\s*){' + englishText + '}', 'g');
+                // make sure the spacing matches in the replacement
+                var replacement = '\\' + cmd + '$1{' + translatedText + '}';
+                translatedMath = translatedMath.replace(regex, replacement);
+            });
+        };
+
+        for (var _iterator = Object.entries(dict)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            _loop();
         }
-
-        var englishText = _ref[0];
-        var translatedText = _ref[1];
-
-        textCommands.forEach(function (cmd) {
-            var regex = new RegExp('\\\\' + cmd + '(\\s*){' + englishText + '}', 'g');
-            // make sure the spacing matches in the replacement
-            var replacement = '\\' + cmd + '$1{' + translatedText + '}';
-            translatedMath = translatedMath.replace(regex, replacement);
-        });
-    };
-
-    for (var _iterator = Object.entries(dict), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
-        var _ref;
-
-        var _ret2 = _loop();
-
-        if (_ret2 === 'break') break;
+    } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion && _iterator['return']) {
+                _iterator['return']();
+            }
+        } finally {
+            if (_didIteratorError) {
+                throw _iteratorError;
+            }
+        }
     }
+
     return translatedMath;
 }
 
@@ -449,10 +476,12 @@ function populateTemplate(template, englishStr, lang) {
 
     var maths = englishStr.match(MATH_REGEX) || [];
     var graphies = englishStr.match(GRAPHIE_REGEX) || [];
+    var images = englishStr.match(IMAGE_REGEX) || [];
     var widgets = englishStr.match(WIDGET_REGEX) || [];
 
     var mathIndex = 0;
     var graphieIndex = 0;
+    var imageIndex = 0;
     var widgetIndex = 0;
 
     maths = maths.map(function (math) {
@@ -467,6 +496,8 @@ function populateTemplate(template, englishStr, lang) {
             return maths[template.mathMapping.englishToTranslated[mathIndex++]];
         }).replace(/__GRAPHIE__/g, function () {
             return graphies[template.graphieMapping[graphieIndex++]];
+        }).replace(/__IMAGE__/g, function () {
+            return images[template.imageMapping[imageIndex++]];
         }).replace(/__WIDGET__/g, function () {
             return widgets[template.widgetMapping[widgetIndex++]];
         });
@@ -537,139 +568,152 @@ var TranslationAssistant = (function () {
      * when passed one of the items.
      */
 
-    TranslationAssistant.prototype.suggest = function suggest(itemsToTranslate) {
-        var _this = this;
+    _createClass(TranslationAssistant, [{
+        key: 'suggest',
+        value: function suggest(itemsToTranslate) {
+            var _this = this;
 
-        var suggestionGroups = this.suggestionGroups;
-        var lang = this.lang;
+            var suggestionGroups = this.suggestionGroups;
+            var lang = this.lang;
 
-        return itemsToTranslate.map(function (item) {
-            var englishStr = rtrim(_this.getEnglishStr(item));
-            var normalStr = stringToGroupKey(englishStr);
-            var normalObj = JSON.parse(normalStr);
+            return itemsToTranslate.map(function (item) {
+                var englishStr = rtrim(_this.getEnglishStr(item));
+                var normalStr = stringToGroupKey(englishStr);
+                var normalObj = JSON.parse(normalStr);
 
-            // Translate items that are only math, a graphie, or a widget.
-            // TODO(kevinb) handle multiple non-nl_text items
-            if (/^(__MATH__|__GRAPHIE__|__WIDGET__)$/.test(normalObj.str)) {
-                if (normalObj.str === '__MATH__') {
-                    // Only translate the math if it doesn't include any
-                    // natural language text in \text and \textbf commands.
-                    if (englishStr.indexOf('\\text') === -1) {
-                        return [item, translateMath(englishStr, lang)];
+                // Translate items that are only math, a graphie, an image, or a
+                // widget. TODO(kevinb) handle multiple non-nl_text items
+                if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
+                    if (normalObj.str === '__MATH__') {
+                        // Only translate the math if it doesn't include any
+                        // natural language text in \text and \textbf commands.
+                        if (englishStr.indexOf('\\text') === -1) {
+                            return [item, translateMath(englishStr, lang)];
+                        }
+                    } else {
+                        return [item, englishStr];
                     }
+                }
+
+                if (suggestionGroups.hasOwnProperty(normalStr)) {
+                    var template = suggestionGroups[normalStr].template;
+
+                    // This error is probably due to math being different between
+                    // the English string and the translated string.
+                    if (template instanceof Error) {
+                        return [item, null];
+                    }
+
+                    if (template) {
+                        var translatedStr = populateTemplate(template, englishStr, lang);
+                        return [item, translatedStr];
+                    }
+                }
+
+                // The item doesn't belong in any of the suggestion groups.
+                return [item, null];
+            });
+        }
+
+        /**
+         * Group objects that contain English strings to translate.
+         *
+         * Groups are determined by the similarity between the English strings
+         * returned by `this.getEnglishStr` on each object in `items`.  In order to
+         * find more matches we ignore math, graphie, and widget substrings.
+         *
+         * Each group contains an array of items that belong in that group and a
+         * translation template if there was at least one item that had a
+         * translation.  Translations are determined by passing each item to
+         * `this.getTranslation`.
+         *
+         * Input:
+         * [
+         *    {
+         *        englishStr: "simplify $2/4$",
+         *        id: 1001,
+         *    }, {
+         *        englishStr: "simplify $3/12$",
+         *        id: 1002,
+         *    }
+         * ];
+         *
+         * Output:
+         * {
+         *    '{str:"simplify __MATH__",text:[[]]}': {
+         *        items: [{
+         *            englishStr: "simplify $2/4$",
+         *            id: 1001,
+         *        }, {
+         *            englishStr: "simplify $3/12$",
+         *            id: 1002,
+         *        }],
+         *        template: { ... }
+         *    },
+         *    ...
+         * }
+         *
+         * @param {Array<Object>} items The items with English strings to group.
+         * @returns {Object} A mapping of groups to items and translation template.
+         */
+    }, {
+        key: 'getSuggestionGroups',
+        value: function getSuggestionGroups(items) {
+            var _this2 = this;
+
+            var suggestionGroups = {};
+
+            items.forEach(function (obj) {
+                var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
+
+                if (suggestionGroups[key]) {
+                    suggestionGroups[key].push(obj);
                 } else {
-                    return [item, englishStr];
+                    suggestionGroups[key] = [obj];
                 }
-            }
+            });
 
-            if (suggestionGroups.hasOwnProperty(normalStr)) {
-                var template = suggestionGroups[normalStr].template;
+            Object.keys(suggestionGroups).forEach(function (key) {
+                var items = suggestionGroups[key];
 
-                // This error is probably due to math being different between
-                // the English string and the translated string.
-                if (template instanceof Error) {
-                    return [item, null];
-                }
+                var _iteratorNormalCompletion2 = true;
+                var _didIteratorError2 = false;
+                var _iteratorError2 = undefined;
 
-                if (template) {
-                    var translatedStr = populateTemplate(template, englishStr, lang);
-                    return [item, translatedStr];
-                }
-            }
+                try {
+                    for (var _iterator2 = items[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                        var item = _step2.value;
 
-            // The item doesn't belong in any of the suggestion groups.
-            return [item, null];
-        });
-    };
+                        var englishStr = _this2.getEnglishStr(item);
+                        var translatedStr = _this2.getTranslation(item);
 
-    /**
-     * Group objects that contain English strings to translate.
-     *
-     * Groups are determined by the similarity between the English strings
-     * returned by `this.getEnglishStr` on each object in `items`.  In order to
-     * find more matches we ignore math, graphie, and widget substrings.
-     *
-     * Each group contains an array of items that belong in that group and a
-     * translation template if there was at least one item that had a
-     * translation.  Translations are determined by passing each item to
-     * `this.getTranslation`.
-     *
-     * Input:
-     * [
-     *    {
-     *        englishStr: "simplify $2/4$",
-     *        id: 1001,
-     *    }, {
-     *        englishStr: "simplify $3/12$",
-     *        id: 1002,
-     *    }
-     * ];
-     *
-     * Output:
-     * {
-     *    '{str:"simplify __MATH__",text:[[]]}': {
-     *        items: [{
-     *            englishStr: "simplify $2/4$",
-     *            id: 1001,
-     *        }, {
-     *            englishStr: "simplify $3/12$",
-     *            id: 1002,
-     *        }],
-     *        template: { ... }
-     *    },
-     *    ...
-     * }
-     *
-     * @param {Array<Object>} items The items with English strings to group.
-     * @returns {Object} A mapping of groups to items and translation template.
-     */
-
-    TranslationAssistant.prototype.getSuggestionGroups = function getSuggestionGroups(items) {
-        var _this2 = this;
-
-        var suggestionGroups = {};
-
-        items.forEach(function (obj) {
-            var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
-
-            if (suggestionGroups[key]) {
-                suggestionGroups[key].push(obj);
-            } else {
-                suggestionGroups[key] = [obj];
-            }
-        });
-
-        Object.keys(suggestionGroups).forEach(function (key) {
-            var items = suggestionGroups[key];
-
-            for (var _iterator2 = items, _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : _iterator2[Symbol.iterator]();;) {
-                var _ref2;
-
-                if (_isArray2) {
-                    if (_i2 >= _iterator2.length) break;
-                    _ref2 = _iterator2[_i2++];
-                } else {
-                    _i2 = _iterator2.next();
-                    if (_i2.done) break;
-                    _ref2 = _i2.value;
+                        if (translatedStr) {
+                            var template = createTemplate(englishStr, translatedStr, _this2.lang);
+                            suggestionGroups[key] = { items: items, template: template };
+                            return;
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError2 = true;
+                    _iteratorError2 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion2 && _iterator2['return']) {
+                            _iterator2['return']();
+                        }
+                    } finally {
+                        if (_didIteratorError2) {
+                            throw _iteratorError2;
+                        }
+                    }
                 }
 
-                var item = _ref2;
+                suggestionGroups[key] = { items: items, template: null };
+            });
 
-                var englishStr = _this2.getEnglishStr(item);
-                var translatedStr = _this2.getTranslation(item);
-
-                if (translatedStr) {
-                    var template = createTemplate(englishStr, translatedStr, _this2.lang);
-                    suggestionGroups[key] = { items: items, template: template };
-                    return;
-                }
-            }
-            suggestionGroups[key] = { items: items, template: null };
-        });
-
-        return suggestionGroups;
-    };
+            return suggestionGroups;
+        }
+    }]);
 
     return TranslationAssistant;
 })();

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -13,9 +13,10 @@ const MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
 // e.g. ![](web+graphie://ka-perseus-graphie.s3.amazonaws.com/542f2b4e297910eed545a5c29c3866918655bab4)
 const GRAPHIE_REGEX = /\!\[\]\([^)]+\)/g;
 
-// Matches image link strings,
-// e.g. 'https://ka-perseus-graphie.s3.amazonaws.com/e75c49cb5753492629016169933ab63af3b9f122.png
-const IMAGE_REGEX = /https:\/\/[^\s]+\.png/g;
+// Matches pure image and graphie link strings,
+// e.g. https://ka-perseus-graphie.s3.amazonaws.com/e75c49cb5753492629016169933ab63af3b9f122.png
+// or web+graphie://ka-perseus-graphie.s3.amazonaws.com/542f2b4e297910eed545a5c29c3866918655bab4
+const IMAGE_REGEX = /https:[^\s]+\.png|web\+graphie:[a-z0-9\.\-/]+(?=[\s,]|$)/g;
 
 // Matches widget strings, e.g. [[☃ Expression 1]]
 const WIDGET_REGEX = /\[\[[\u2603][^\]]+\]\]/g;
@@ -542,7 +543,8 @@ class TranslationAssistant {
             const normalObj = JSON.parse(normalStr);
 
             // Translate items that are only math, a graphie, an image, or a
-            // widget. TODO(kevinb) handle multiple non-nl_text items
+            // widget.
+            // TODO(kevinb) handle multiple non-nl_text items
             if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/
                     .test(normalObj.str)) {
                 if (normalObj.str === '__MATH__') {

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -26,6 +26,23 @@ const graphie4 = makeGraphie();
 const graphie5 = makeGraphie();
 const graphie6 = makeGraphie();
 
+/**
+ * Return a fake image link string.
+ * @returns {String} A fake image link string.
+ */
+function makeImageLink() {
+    const baseURL = 'https://ka-perseus-graphie.s3.amazonaws.com';
+    const id = Date.now() + (1000 * Math.random() | 0);
+    return `${baseURL}/${id}.png`;
+}
+
+const image1 = makeImageLink();
+const image2 = makeImageLink();
+const image3 = makeImageLink();
+const image4 = makeImageLink();
+const image5 = makeImageLink();
+const image6 = makeImageLink();
+
 const getEnglishStr = (item) => item.englishStr;
 const getTranslation = (item) => item.translatedStr;
 const lang = 'fr';
@@ -191,6 +208,21 @@ describe('TranslationAssistant', function() {
                 translatedStr: '',
             }];
             const translatedStr = [graphie, null];
+
+            assertSuggestions(allItems, itemsToTranslate, translatedStr);
+        });
+
+        it('should return the same image link', function() {
+            const imageLink = makeImageLink();
+            const allItems = [];
+            const itemsToTranslate = [{
+                englishStr: imageLink,
+                translatedStr: '',
+            }, {
+                englishStr: 'hello',
+                translatedStr: '',
+            }];
+            const translatedStr = [imageLink, null];
 
             assertSuggestions(allItems, itemsToTranslate, translatedStr);
         });
@@ -475,6 +507,55 @@ describe('TranslationAssistant (graphie)', function() {
         }];
 
         assertSuggestions(allItems, itemsToTranslate, [graphie2]);
+    });
+});
+
+describe('TranslationAssistant (image links)', function() {
+    it('should handle multiple image links on multiple lines', function() {
+        const allItems = [{
+            englishStr: `simplify ${image1}, answer ${image2}\n\n` +
+                `hints: ${image3}`,
+            translatedStr: `simplifyz ${image1}, answerz ${image2}\n\n` +
+                `hintz: ${image3}`,
+        }];
+        const itemsToTranslate = [{
+            englishStr: `simplify ${image4}, answer ${image5}\n\n` +
+                `hints: ${image6}`,
+            translatedStr: '',
+        }];
+
+        assertSuggestions(allItems, itemsToTranslate, [
+            `simplifyz ${image4}, answerz ${image5}\n\n` +
+            `hintz: ${image6}`,
+        ]);
+    });
+
+    it('should handle translations that re-order image links', function() {
+        const allItems = [{
+            englishStr: `simplify ${image1}, answer ${image2}`,
+            translatedStr: `answerz ${image2}, simplifyz ${image1}`,
+        }];
+        const itemsToTranslate = [{
+            englishStr: `simplify ${image3}, answer ${image4}`,
+            translatedStr: '',
+        }];
+
+        assertSuggestions(allItems, itemsToTranslate, [
+            `answerz ${image4}, simplifyz ${image3}`,
+        ]);
+    });
+
+    it('should handle strings that are only image links', function() {
+        const allItems = [{
+            englishStr: image1,
+            translatedStr: image1,
+        }];
+        const itemsToTranslate = [{
+            englishStr: image2,
+            translatedStr: '',
+        }];
+
+        assertSuggestions(allItems, itemsToTranslate, [image2]);
     });
 });
 

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -43,6 +43,23 @@ const image4 = makeImageLink();
 const image5 = makeImageLink();
 const image6 = makeImageLink();
 
+/**
+ * Return a fake graphie link string.
+ * @returns {String} A fake graphie link string.
+ */
+function makeGraphieLink() {
+    const baseURL = 'web+graphie://ka-perseus-graphie.s3.amazonaws.com';
+    const id = Date.now() + (1000 * Math.random() | 0);
+    return `${baseURL}/${id}`;
+}
+
+const graphieLink1 = makeGraphieLink();
+const graphieLink2 = makeGraphieLink();
+const graphieLink3 = makeGraphieLink();
+const graphieLink4 = makeGraphieLink();
+const graphieLink5 = makeGraphieLink();
+const graphieLink6 = makeGraphieLink();
+
 const getEnglishStr = (item) => item.englishStr;
 const getTranslation = (item) => item.translatedStr;
 const lang = 'fr';
@@ -462,7 +479,7 @@ describe('TranslationAssistant (math)', function() {
 });
 
 describe('TranslationAssistant (graphie)', function() {
-    it('should handle multiple math on multiple lines', function() {
+    it('should handle multiple graphies on multiple lines', function() {
         const allItems = [{
             englishStr: `simplify ${graphie1}, answer ${graphie2}\n\n` +
                 `hints: ${graphie3}`,
@@ -510,7 +527,7 @@ describe('TranslationAssistant (graphie)', function() {
     });
 });
 
-describe('TranslationAssistant (image links)', function() {
+describe('TranslationAssistant (image and graphie links)', function() {
     it('should handle multiple image links on multiple lines', function() {
         const allItems = [{
             englishStr: `simplify ${image1}, answer ${image2}\n\n` +
@@ -556,6 +573,53 @@ describe('TranslationAssistant (image links)', function() {
         }];
 
         assertSuggestions(allItems, itemsToTranslate, [image2]);
+    });
+
+    it('should handle multiple graphie links on multiple lines', function() {
+        const allItems = [{
+            englishStr: `simplify ${graphieLink1} to ${graphieLink2}\n\n` +
+                `hints: ${graphieLink3}`,
+            translatedStr: `simplifyz ${graphieLink1} toz ${graphieLink2}\n\n` +
+                `hintz: ${graphieLink3}`,
+        }];
+        const itemsToTranslate = [{
+            englishStr: `simplify ${graphieLink4} to ${graphieLink5}\n\n` +
+                `hints: ${graphieLink6}`,
+            translatedStr: '',
+        }];
+
+        assertSuggestions(allItems, itemsToTranslate, [
+            `simplifyz ${graphieLink4} toz ${graphieLink5}\n\n` +
+            `hintz: ${graphieLink6}`,
+        ]);
+    });
+
+    it('should handle translations that re-order graphie links', function() {
+        const allItems = [{
+            englishStr: `simplify ${graphieLink1}, answer ${graphieLink2}`,
+            translatedStr: `answerz ${graphieLink2}, simplifyz ${graphieLink1}`,
+        }];
+        const itemsToTranslate = [{
+            englishStr: `simplify ${graphieLink3}, answer ${graphieLink4}`,
+            translatedStr: '',
+        }];
+
+        assertSuggestions(allItems, itemsToTranslate, [
+            `answerz ${graphieLink4}, simplifyz ${graphieLink3}`,
+        ]);
+    });
+
+    it('should handle strings that are only graphie links', function() {
+        const allItems = [{
+            englishStr: graphieLink1,
+            translatedStr: graphieLink1,
+        }];
+        const itemsToTranslate = [{
+            englishStr: graphieLink2,
+            translatedStr: '',
+        }];
+
+        assertSuggestions(allItems, itemsToTranslate, [graphieLink2]);
     });
 });
 


### PR DESCRIPTION
Implemented support for detecting new type of non-translatable string segments - pure image links. It was done in the same manner as was already done for graphie images. Test suite has also been extended with 4 new tests.

This closes #3 where more details on the issue are available.