### PR TITLE
Handle special characters inside \text commands.

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -8,10 +8,6 @@
 // $\text{cost} = \$4$
 'use strict';
 
-var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
@@ -216,11 +212,9 @@ function getMathDictionary(englishStr, translatedStr) {
     inputs.forEach(function (input) {
         var normalized = input;
 
-        replaceRegexes.forEach(function (_ref) {
-            var _ref2 = _slicedToArray(_ref, 2);
-
-            var regex = _ref2[0];
-            var str = _ref2[1];
+        replaceRegexes.forEach(function (_ref3) {
+            var regex = _ref3[0];
+            var str = _ref3[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -234,11 +228,9 @@ function getMathDictionary(englishStr, translatedStr) {
     outputs.forEach(function (output) {
         var normalized = output;
 
-        replaceRegexes.forEach(function (_ref3) {
-            var _ref32 = _slicedToArray(_ref3, 2);
-
-            var regex = _ref32[0];
-            var str = _ref32[1];
+        replaceRegexes.forEach(function (_ref4) {
+            var regex = _ref4[0];
+            var str = _ref4[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -254,11 +246,9 @@ function getMathDictionary(englishStr, translatedStr) {
     var matchRegexes = [[/__TEXT__/, TEXT_REGEX], [/__TEXTBF__/, TEXTBF_REGEX]];
 
     Object.keys(inputMap).forEach(function (key) {
-        matchRegexes.forEach(function (_ref4) {
-            var _ref42 = _slicedToArray(_ref4, 2);
-
-            var match = _ref42[0];
-            var regex = _ref42[1];
+        matchRegexes.forEach(function (_ref5) {
+            var match = _ref5[0];
+            var regex = _ref5[1];
 
             if (match.test(key)) {
                 var _ret = (function () {
@@ -381,14 +371,16 @@ function rtrim(str) {
 }
 
 /**
+ * Escape any string to create regular expression
+ *
  * See: https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/
  *
  * @param {String} str A string to be matched in regular expr
  * @returns {String} The string with escaped characters
  */
-RegExp.escape = function (str) {
+function escapeForRegex(str) {
     return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-};
+}
 
 /**
  * Translate the text inside \\text{} and \\textbf blocks.
@@ -405,44 +397,35 @@ function replaceTextInMath(englishMath, dict) {
 
     var textCommands = ['text', 'textbf'];
 
-    var _iteratorNormalCompletion = true;
-    var _didIteratorError = false;
-    var _iteratorError = undefined;
-
-    try {
-        var _loop = function () {
-            var _step$value = _slicedToArray(_step.value, 2);
-
-            var englishText = _step$value[0];
-            var translatedText = _step$value[1];
-
-            textCommands.forEach(function (cmd) {
-                var escapedEnglishText = RegExp.escape(englishText);
-                var regex = new RegExp('\\\\' + cmd + '(\\s*){' + escapedEnglishText + '}', 'g');
-                // make sure the spacing matches in the replacement
-                var replacement = '\\' + cmd + '$1{' + translatedText + '}';
-                translatedMath = translatedMath.replace(regex, replacement);
-            });
-        };
-
-        for (var _iterator = Object.entries(dict)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-            _loop();
+    var _loop = function () {
+        if (_isArray) {
+            if (_i >= _iterator.length) return 'break';
+            _ref = _iterator[_i++];
+        } else {
+            _i = _iterator.next();
+            if (_i.done) return 'break';
+            _ref = _i.value;
         }
-    } catch (err) {
-        _didIteratorError = true;
-        _iteratorError = err;
-    } finally {
-        try {
-            if (!_iteratorNormalCompletion && _iterator['return']) {
-                _iterator['return']();
-            }
-        } finally {
-            if (_didIteratorError) {
-                throw _iteratorError;
-            }
-        }
+
+        var englishText = _ref[0];
+        var translatedText = _ref[1];
+
+        textCommands.forEach(function (cmd) {
+            var escapedEnglishText = escapeForRegex(englishText);
+            var regex = new RegExp('\\\\' + cmd + '(\\s*){' + escapedEnglishText + '}', 'g');
+            // make sure the spacing matches in the replacement
+            var replacement = '\\' + cmd + '$1{' + translatedText + '}';
+            translatedMath = translatedMath.replace(regex, replacement);
+        });
+    };
+
+    for (var _iterator = Object.entries(dict), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
+        var _ref;
+
+        var _ret2 = _loop();
+
+        if (_ret2 === 'break') break;
     }
-
     return translatedMath;
 }
 
@@ -580,153 +563,140 @@ var TranslationAssistant = (function () {
      * when passed one of the items.
      */
 
-    _createClass(TranslationAssistant, [{
-        key: 'suggest',
-        value: function suggest(itemsToTranslate) {
-            var _this = this;
+    TranslationAssistant.prototype.suggest = function suggest(itemsToTranslate) {
+        var _this = this;
 
-            var suggestionGroups = this.suggestionGroups;
-            var lang = this.lang;
+        var suggestionGroups = this.suggestionGroups;
+        var lang = this.lang;
 
-            return itemsToTranslate.map(function (item) {
-                var englishStr = rtrim(_this.getEnglishStr(item));
-                var normalStr = stringToGroupKey(englishStr);
-                var normalObj = JSON.parse(normalStr);
+        return itemsToTranslate.map(function (item) {
+            var englishStr = rtrim(_this.getEnglishStr(item));
+            var normalStr = stringToGroupKey(englishStr);
+            var normalObj = JSON.parse(normalStr);
 
-                // Translate items that are only math, a graphie, an image, or a
-                // widget.
-                // TODO(kevinb) handle multiple non-nl_text items
-                if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
-                    if (normalObj.str === '__MATH__') {
-                        // Only translate the math if it doesn't include any
-                        // natural language text in \text and \textbf commands.
-                        if (englishStr.indexOf('\\text') === -1) {
-                            return [item, translateMath(englishStr, lang)];
-                        }
-                    } else {
-                        return [item, englishStr];
+            // Translate items that are only math, a graphie, an image, or a
+            // widget.
+            // TODO(kevinb) handle multiple non-nl_text items
+            if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
+                if (normalObj.str === '__MATH__') {
+                    // Only translate the math if it doesn't include any
+                    // natural language text in \text and \textbf commands.
+                    if (englishStr.indexOf('\\text') === -1) {
+                        return [item, translateMath(englishStr, lang)];
                     }
-                }
-
-                if (suggestionGroups.hasOwnProperty(normalStr)) {
-                    var template = suggestionGroups[normalStr].template;
-
-                    // This error is probably due to math being different between
-                    // the English string and the translated string.
-                    if (template instanceof Error) {
-                        return [item, null];
-                    }
-
-                    if (template) {
-                        var translatedStr = populateTemplate(template, englishStr, lang);
-                        return [item, translatedStr];
-                    }
-                }
-
-                // The item doesn't belong in any of the suggestion groups.
-                return [item, null];
-            });
-        }
-
-        /**
-         * Group objects that contain English strings to translate.
-         *
-         * Groups are determined by the similarity between the English strings
-         * returned by `this.getEnglishStr` on each object in `items`.  In order to
-         * find more matches we ignore math, graphie, and widget substrings.
-         *
-         * Each group contains an array of items that belong in that group and a
-         * translation template if there was at least one item that had a
-         * translation.  Translations are determined by passing each item to
-         * `this.getTranslation`.
-         *
-         * Input:
-         * [
-         *    {
-         *        englishStr: "simplify $2/4$",
-         *        id: 1001,
-         *    }, {
-         *        englishStr: "simplify $3/12$",
-         *        id: 1002,
-         *    }
-         * ];
-         *
-         * Output:
-         * {
-         *    '{str:"simplify __MATH__",text:[[]]}': {
-         *        items: [{
-         *            englishStr: "simplify $2/4$",
-         *            id: 1001,
-         *        }, {
-         *            englishStr: "simplify $3/12$",
-         *            id: 1002,
-         *        }],
-         *        template: { ... }
-         *    },
-         *    ...
-         * }
-         *
-         * @param {Array<Object>} items The items with English strings to group.
-         * @returns {Object} A mapping of groups to items and translation template.
-         */
-    }, {
-        key: 'getSuggestionGroups',
-        value: function getSuggestionGroups(items) {
-            var _this2 = this;
-
-            var suggestionGroups = {};
-
-            items.forEach(function (obj) {
-                var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
-
-                if (suggestionGroups[key]) {
-                    suggestionGroups[key].push(obj);
                 } else {
-                    suggestionGroups[key] = [obj];
+                    return [item, englishStr];
                 }
-            });
+            }
 
-            Object.keys(suggestionGroups).forEach(function (key) {
-                var items = suggestionGroups[key];
+            if (suggestionGroups.hasOwnProperty(normalStr)) {
+                var template = suggestionGroups[normalStr].template;
 
-                var _iteratorNormalCompletion2 = true;
-                var _didIteratorError2 = false;
-                var _iteratorError2 = undefined;
-
-                try {
-                    for (var _iterator2 = items[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-                        var item = _step2.value;
-
-                        var englishStr = _this2.getEnglishStr(item);
-                        var translatedStr = _this2.getTranslation(item);
-
-                        if (translatedStr) {
-                            var template = createTemplate(englishStr, translatedStr, _this2.lang);
-                            suggestionGroups[key] = { items: items, template: template };
-                            return;
-                        }
-                    }
-                } catch (err) {
-                    _didIteratorError2 = true;
-                    _iteratorError2 = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion2 && _iterator2['return']) {
-                            _iterator2['return']();
-                        }
-                    } finally {
-                        if (_didIteratorError2) {
-                            throw _iteratorError2;
-                        }
-                    }
+                // This error is probably due to math being different between
+                // the English string and the translated string.
+                if (template instanceof Error) {
+                    return [item, null];
                 }
 
-                suggestionGroups[key] = { items: items, template: null };
-            });
+                if (template) {
+                    var translatedStr = populateTemplate(template, englishStr, lang);
+                    return [item, translatedStr];
+                }
+            }
 
-            return suggestionGroups;
-        }
-    }]);
+            // The item doesn't belong in any of the suggestion groups.
+            return [item, null];
+        });
+    };
+
+    /**
+     * Group objects that contain English strings to translate.
+     *
+     * Groups are determined by the similarity between the English strings
+     * returned by `this.getEnglishStr` on each object in `items`.  In order to
+     * find more matches we ignore math, graphie, and widget substrings.
+     *
+     * Each group contains an array of items that belong in that group and a
+     * translation template if there was at least one item that had a
+     * translation.  Translations are determined by passing each item to
+     * `this.getTranslation`.
+     *
+     * Input:
+     * [
+     *    {
+     *        englishStr: "simplify $2/4$",
+     *        id: 1001,
+     *    }, {
+     *        englishStr: "simplify $3/12$",
+     *        id: 1002,
+     *    }
+     * ];
+     *
+     * Output:
+     * {
+     *    '{str:"simplify __MATH__",text:[[]]}': {
+     *        items: [{
+     *            englishStr: "simplify $2/4$",
+     *            id: 1001,
+     *        }, {
+     *            englishStr: "simplify $3/12$",
+     *            id: 1002,
+     *        }],
+     *        template: { ... }
+     *    },
+     *    ...
+     * }
+     *
+     * @param {Array<Object>} items The items with English strings to group.
+     * @returns {Object} A mapping of groups to items and translation template.
+     */
+
+    TranslationAssistant.prototype.getSuggestionGroups = function getSuggestionGroups(items) {
+        var _this2 = this;
+
+        var suggestionGroups = {};
+
+        items.forEach(function (obj) {
+            var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
+
+            if (suggestionGroups[key]) {
+                suggestionGroups[key].push(obj);
+            } else {
+                suggestionGroups[key] = [obj];
+            }
+        });
+
+        Object.keys(suggestionGroups).forEach(function (key) {
+            var items = suggestionGroups[key];
+
+            for (var _iterator2 = items, _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : _iterator2[Symbol.iterator]();;) {
+                var _ref2;
+
+                if (_isArray2) {
+                    if (_i2 >= _iterator2.length) break;
+                    _ref2 = _iterator2[_i2++];
+                } else {
+                    _i2 = _iterator2.next();
+                    if (_i2.done) break;
+                    _ref2 = _i2.value;
+                }
+
+                var item = _ref2;
+
+                var englishStr = _this2.getEnglishStr(item);
+                var translatedStr = _this2.getTranslation(item);
+
+                if (translatedStr) {
+                    var template = createTemplate(englishStr, translatedStr, _this2.lang);
+                    suggestionGroups[key] = { items: items, template: template };
+                    return;
+                }
+            }
+            suggestionGroups[key] = { items: items, template: null };
+        });
+
+        return suggestionGroups;
+    };
 
     return TranslationAssistant;
 })();

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -8,6 +8,10 @@
 // $\text{cost} = \$4$
 'use strict';
 
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
@@ -212,9 +216,11 @@ function getMathDictionary(englishStr, translatedStr) {
     inputs.forEach(function (input) {
         var normalized = input;
 
-        replaceRegexes.forEach(function (_ref3) {
-            var regex = _ref3[0];
-            var str = _ref3[1];
+        replaceRegexes.forEach(function (_ref) {
+            var _ref2 = _slicedToArray(_ref, 2);
+
+            var regex = _ref2[0];
+            var str = _ref2[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -228,9 +234,11 @@ function getMathDictionary(englishStr, translatedStr) {
     outputs.forEach(function (output) {
         var normalized = output;
 
-        replaceRegexes.forEach(function (_ref4) {
-            var regex = _ref4[0];
-            var str = _ref4[1];
+        replaceRegexes.forEach(function (_ref3) {
+            var _ref32 = _slicedToArray(_ref3, 2);
+
+            var regex = _ref32[0];
+            var str = _ref32[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -246,9 +254,11 @@ function getMathDictionary(englishStr, translatedStr) {
     var matchRegexes = [[/__TEXT__/, TEXT_REGEX], [/__TEXTBF__/, TEXTBF_REGEX]];
 
     Object.keys(inputMap).forEach(function (key) {
-        matchRegexes.forEach(function (_ref5) {
-            var match = _ref5[0];
-            var regex = _ref5[1];
+        matchRegexes.forEach(function (_ref4) {
+            var _ref42 = _slicedToArray(_ref4, 2);
+
+            var match = _ref42[0];
+            var regex = _ref42[1];
 
             if (match.test(key)) {
                 var _ret = (function () {
@@ -371,6 +381,16 @@ function rtrim(str) {
 }
 
 /**
+ * See: https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/
+ *
+ * @param {String} str A string to be matched in regular expr
+ * @returns {String} The string with escaped characters
+ */
+RegExp.escape = function (str) {
+    return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+};
+
+/**
  * Translate the text inside \\text{} and \\textbf blocks.
  *
  * @param {string} englishMath The math string to translate.  If a English
@@ -385,34 +405,44 @@ function replaceTextInMath(englishMath, dict) {
 
     var textCommands = ['text', 'textbf'];
 
-    var _loop = function () {
-        if (_isArray) {
-            if (_i >= _iterator.length) return 'break';
-            _ref = _iterator[_i++];
-        } else {
-            _i = _iterator.next();
-            if (_i.done) return 'break';
-            _ref = _i.value;
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+        var _loop = function () {
+            var _step$value = _slicedToArray(_step.value, 2);
+
+            var englishText = _step$value[0];
+            var translatedText = _step$value[1];
+
+            textCommands.forEach(function (cmd) {
+                var escapedEnglishText = RegExp.escape(englishText);
+                var regex = new RegExp('\\\\' + cmd + '(\\s*){' + escapedEnglishText + '}', 'g');
+                // make sure the spacing matches in the replacement
+                var replacement = '\\' + cmd + '$1{' + translatedText + '}';
+                translatedMath = translatedMath.replace(regex, replacement);
+            });
+        };
+
+        for (var _iterator = Object.entries(dict)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            _loop();
         }
-
-        var englishText = _ref[0];
-        var translatedText = _ref[1];
-
-        textCommands.forEach(function (cmd) {
-            var regex = new RegExp('\\\\' + cmd + '(\\s*){' + englishText + '}', 'g');
-            // make sure the spacing matches in the replacement
-            var replacement = '\\' + cmd + '$1{' + translatedText + '}';
-            translatedMath = translatedMath.replace(regex, replacement);
-        });
-    };
-
-    for (var _iterator = Object.entries(dict), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
-        var _ref;
-
-        var _ret2 = _loop();
-
-        if (_ret2 === 'break') break;
+    } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion && _iterator['return']) {
+                _iterator['return']();
+            }
+        } finally {
+            if (_didIteratorError) {
+                throw _iteratorError;
+            }
+        }
     }
+
     return translatedMath;
 }
 
@@ -550,140 +580,153 @@ var TranslationAssistant = (function () {
      * when passed one of the items.
      */
 
-    TranslationAssistant.prototype.suggest = function suggest(itemsToTranslate) {
-        var _this = this;
+    _createClass(TranslationAssistant, [{
+        key: 'suggest',
+        value: function suggest(itemsToTranslate) {
+            var _this = this;
 
-        var suggestionGroups = this.suggestionGroups;
-        var lang = this.lang;
+            var suggestionGroups = this.suggestionGroups;
+            var lang = this.lang;
 
-        return itemsToTranslate.map(function (item) {
-            var englishStr = rtrim(_this.getEnglishStr(item));
-            var normalStr = stringToGroupKey(englishStr);
-            var normalObj = JSON.parse(normalStr);
+            return itemsToTranslate.map(function (item) {
+                var englishStr = rtrim(_this.getEnglishStr(item));
+                var normalStr = stringToGroupKey(englishStr);
+                var normalObj = JSON.parse(normalStr);
 
-            // Translate items that are only math, a graphie, an image, or a
-            // widget.
-            // TODO(kevinb) handle multiple non-nl_text items
-            if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
-                if (normalObj.str === '__MATH__') {
-                    // Only translate the math if it doesn't include any
-                    // natural language text in \text and \textbf commands.
-                    if (englishStr.indexOf('\\text') === -1) {
-                        return [item, translateMath(englishStr, lang)];
+                // Translate items that are only math, a graphie, an image, or a
+                // widget.
+                // TODO(kevinb) handle multiple non-nl_text items
+                if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
+                    if (normalObj.str === '__MATH__') {
+                        // Only translate the math if it doesn't include any
+                        // natural language text in \text and \textbf commands.
+                        if (englishStr.indexOf('\\text') === -1) {
+                            return [item, translateMath(englishStr, lang)];
+                        }
+                    } else {
+                        return [item, englishStr];
                     }
+                }
+
+                if (suggestionGroups.hasOwnProperty(normalStr)) {
+                    var template = suggestionGroups[normalStr].template;
+
+                    // This error is probably due to math being different between
+                    // the English string and the translated string.
+                    if (template instanceof Error) {
+                        return [item, null];
+                    }
+
+                    if (template) {
+                        var translatedStr = populateTemplate(template, englishStr, lang);
+                        return [item, translatedStr];
+                    }
+                }
+
+                // The item doesn't belong in any of the suggestion groups.
+                return [item, null];
+            });
+        }
+
+        /**
+         * Group objects that contain English strings to translate.
+         *
+         * Groups are determined by the similarity between the English strings
+         * returned by `this.getEnglishStr` on each object in `items`.  In order to
+         * find more matches we ignore math, graphie, and widget substrings.
+         *
+         * Each group contains an array of items that belong in that group and a
+         * translation template if there was at least one item that had a
+         * translation.  Translations are determined by passing each item to
+         * `this.getTranslation`.
+         *
+         * Input:
+         * [
+         *    {
+         *        englishStr: "simplify $2/4$",
+         *        id: 1001,
+         *    }, {
+         *        englishStr: "simplify $3/12$",
+         *        id: 1002,
+         *    }
+         * ];
+         *
+         * Output:
+         * {
+         *    '{str:"simplify __MATH__",text:[[]]}': {
+         *        items: [{
+         *            englishStr: "simplify $2/4$",
+         *            id: 1001,
+         *        }, {
+         *            englishStr: "simplify $3/12$",
+         *            id: 1002,
+         *        }],
+         *        template: { ... }
+         *    },
+         *    ...
+         * }
+         *
+         * @param {Array<Object>} items The items with English strings to group.
+         * @returns {Object} A mapping of groups to items and translation template.
+         */
+    }, {
+        key: 'getSuggestionGroups',
+        value: function getSuggestionGroups(items) {
+            var _this2 = this;
+
+            var suggestionGroups = {};
+
+            items.forEach(function (obj) {
+                var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
+
+                if (suggestionGroups[key]) {
+                    suggestionGroups[key].push(obj);
                 } else {
-                    return [item, englishStr];
+                    suggestionGroups[key] = [obj];
                 }
-            }
+            });
 
-            if (suggestionGroups.hasOwnProperty(normalStr)) {
-                var template = suggestionGroups[normalStr].template;
+            Object.keys(suggestionGroups).forEach(function (key) {
+                var items = suggestionGroups[key];
 
-                // This error is probably due to math being different between
-                // the English string and the translated string.
-                if (template instanceof Error) {
-                    return [item, null];
-                }
+                var _iteratorNormalCompletion2 = true;
+                var _didIteratorError2 = false;
+                var _iteratorError2 = undefined;
 
-                if (template) {
-                    var translatedStr = populateTemplate(template, englishStr, lang);
-                    return [item, translatedStr];
-                }
-            }
+                try {
+                    for (var _iterator2 = items[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                        var item = _step2.value;
 
-            // The item doesn't belong in any of the suggestion groups.
-            return [item, null];
-        });
-    };
+                        var englishStr = _this2.getEnglishStr(item);
+                        var translatedStr = _this2.getTranslation(item);
 
-    /**
-     * Group objects that contain English strings to translate.
-     *
-     * Groups are determined by the similarity between the English strings
-     * returned by `this.getEnglishStr` on each object in `items`.  In order to
-     * find more matches we ignore math, graphie, and widget substrings.
-     *
-     * Each group contains an array of items that belong in that group and a
-     * translation template if there was at least one item that had a
-     * translation.  Translations are determined by passing each item to
-     * `this.getTranslation`.
-     *
-     * Input:
-     * [
-     *    {
-     *        englishStr: "simplify $2/4$",
-     *        id: 1001,
-     *    }, {
-     *        englishStr: "simplify $3/12$",
-     *        id: 1002,
-     *    }
-     * ];
-     *
-     * Output:
-     * {
-     *    '{str:"simplify __MATH__",text:[[]]}': {
-     *        items: [{
-     *            englishStr: "simplify $2/4$",
-     *            id: 1001,
-     *        }, {
-     *            englishStr: "simplify $3/12$",
-     *            id: 1002,
-     *        }],
-     *        template: { ... }
-     *    },
-     *    ...
-     * }
-     *
-     * @param {Array<Object>} items The items with English strings to group.
-     * @returns {Object} A mapping of groups to items and translation template.
-     */
-
-    TranslationAssistant.prototype.getSuggestionGroups = function getSuggestionGroups(items) {
-        var _this2 = this;
-
-        var suggestionGroups = {};
-
-        items.forEach(function (obj) {
-            var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
-
-            if (suggestionGroups[key]) {
-                suggestionGroups[key].push(obj);
-            } else {
-                suggestionGroups[key] = [obj];
-            }
-        });
-
-        Object.keys(suggestionGroups).forEach(function (key) {
-            var items = suggestionGroups[key];
-
-            for (var _iterator2 = items, _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : _iterator2[Symbol.iterator]();;) {
-                var _ref2;
-
-                if (_isArray2) {
-                    if (_i2 >= _iterator2.length) break;
-                    _ref2 = _iterator2[_i2++];
-                } else {
-                    _i2 = _iterator2.next();
-                    if (_i2.done) break;
-                    _ref2 = _i2.value;
+                        if (translatedStr) {
+                            var template = createTemplate(englishStr, translatedStr, _this2.lang);
+                            suggestionGroups[key] = { items: items, template: template };
+                            return;
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError2 = true;
+                    _iteratorError2 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion2 && _iterator2['return']) {
+                            _iterator2['return']();
+                        }
+                    } finally {
+                        if (_didIteratorError2) {
+                            throw _iteratorError2;
+                        }
+                    }
                 }
 
-                var item = _ref2;
+                suggestionGroups[key] = { items: items, template: null };
+            });
 
-                var englishStr = _this2.getEnglishStr(item);
-                var translatedStr = _this2.getTranslation(item);
-
-                if (translatedStr) {
-                    var template = createTemplate(englishStr, translatedStr, _this2.lang);
-                    suggestionGroups[key] = { items: items, template: template };
-                    return;
-                }
-            }
-            suggestionGroups[key] = { items: items, template: null };
-        });
-
-        return suggestionGroups;
-    };
+            return suggestionGroups;
+        }
+    }]);
 
     return TranslationAssistant;
 })();

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -375,14 +375,16 @@ function rtrim(str) {
 }
 
 /**
+ * Escape any string to create regular expression
+ *
  * See: https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/
  *
  * @param {String} str A string to be matched in regular expr
  * @returns {String} The string with escaped characters
  */
-RegExp.escape = function(str) {
+function escapeForRegex(str) {
     return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-};
+}
 
 /**
  * Translate the text inside \\text{} and \\textbf blocks.
@@ -404,7 +406,7 @@ function replaceTextInMath(englishMath, dict) {
 
     for (const [englishText, translatedText] of Object.entries(dict)) {
         textCommands.forEach((cmd) => {
-            const escapedEnglishText = RegExp.escape(englishText);
+            const escapedEnglishText = escapeForRegex(englishText);
             const regex = new RegExp(`\\\\${cmd}(\\s*){${escapedEnglishText}}`,
                   'g');
             // make sure the spacing matches in the replacement

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -375,6 +375,16 @@ function rtrim(str) {
 }
 
 /**
+ * See: https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/
+ *
+ * @param {String} str A string to be matched in regular expr
+ * @returns {String} The string with escaped characters
+ */
+RegExp.escape = function(str) {
+    return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+};
+
+/**
  * Translate the text inside \\text{} and \\textbf blocks.
  *
  * @param {string} englishMath The math string to translate.  If a English
@@ -394,7 +404,9 @@ function replaceTextInMath(englishMath, dict) {
 
     for (const [englishText, translatedText] of Object.entries(dict)) {
         textCommands.forEach((cmd) => {
-            const regex = new RegExp(`\\\\${cmd}(\\s*){${englishText}}`, 'g');
+            const escapedEnglishText = RegExp.escape(englishText);
+            const regex = new RegExp(`\\\\${cmd}(\\s*){${escapedEnglishText}}`,
+                  'g');
             // make sure the spacing matches in the replacement
             const replacement = `\\${cmd}$1{${translatedText}}`;
             translatedMath = translatedMath.replace(regex, replacement);

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -996,6 +996,23 @@ describe('TranslationAssistant (\\text{}, \\textbf{})', function() {
             translated: '',
         }], ['$\\textbf{Fläche}} = 12 \\textbf { Quadratzentimeter}$']);
     });
+
+    it('should handle special characters inside \\text', function() {
+        const allItems = [{
+            englishStr: '$6 \\text{( . )}$',
+            translatedStr: '$6 \\text{)}$',
+        }];
+
+        const itemsToTranslate = [{
+            englishStr: '$5 \\text{( . )}$',
+            translatedStr: '',
+        }];
+
+        assertSuggestions(allItems, itemsToTranslate, [
+            '$5 \\text{)}$',
+        ]);
+    });
+
 });
 
 describe('TranslationAssistant **bold**', function() {

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -1013,6 +1013,22 @@ describe('TranslationAssistant (\\text{}, \\textbf{})', function() {
         ]);
     });
 
+    it('should handle special characters inside \\textbf', function() {
+        const allItems = [{
+            englishStr: '$6 \\textbf{( . )}$',
+            translatedStr: '$6 \\textbf{)}$',
+        }];
+
+        const itemsToTranslate = [{
+            englishStr: '$5 \\textbf{( . )}$',
+            translatedStr: '',
+        }];
+
+        assertSuggestions(allItems, itemsToTranslate, [
+            '$5 \\textbf{)}$',
+        ]);
+    });
+
 });
 
 describe('TranslationAssistant **bold**', function() {


### PR DESCRIPTION
ST for `\text{(english text)}` would fail because the unescaped parentheses were messing up the regexes.

The issue was reported on [JIRA IC-129](https://khanacademy.atlassian.net/browse/IC-129).

(Note of caution, this is my very first pull request so hopefully I am not messing something up :slightly_smiling_face:)

PS: I think I signed the CLA couple months ago...