### PR TITLE
Support translations of certain math notation

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -140,11 +140,11 @@ mathDictionary) {
 
     outputs.forEach(function (output, outputIndex) {
         // TODO(danielhollas): Should the following be here?
-        // e.g. should we automatically translate to decimal commas
-        // even if original string was not?
-        if (findRegex === MATH_REGEX) {
-            output = translateMath(output, lang);
-        }
+        // Should we automatically translate math even if translatedStr
+        // was not translated according to our locale rules?
+        //if (findRegex === MATH_REGEX) {
+        //    output = translateMath(output, lang);
+        //}
 
         var inputIndex = inputs.indexOf(output);
         if (inputIndex === -1) {
@@ -361,15 +361,16 @@ function createTemplate(englishStr, translatedStr, lang) {
 
 /**
  * Handles any per language special case translations, e.g. Portuguese uses
- * `sen` instead of `sin`.
+ * `sen` instead of `sin`. Many lang use decimal comma.
+ * According to this table:
+ * https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0
+ *
+ * TODO(danielhollas): For now only the obvious cases were implemented.
  *
  * @param {string} math A math expression to translate for locale.
  * @param {string} lang The locale of the translation language.
  * @returns {string} The translated math expression.
- *
- * TODO(kevinb): handle \text{} inside math.
- * TODO(danielhollas): implement locale specific translations according to:
- * https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0
+ * TODO(danielhollas): Need to update this when new langs join translations
  */
 function translateMath(math, lang) {
 

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -26,7 +26,7 @@ var WIDGET_REGEX = /\[\[[\u2603][^\]]+\]\]/g;
 
 // TODO(michaelpolyak): Add support for other \text commands:
 // https://github.com/Khan/KaTeX/blob/3280652bd68973ad9edd73273137049324c5cab9/src/functions.js#L50
-// Comment(danhollas): Those other commands are rare/non-existent in KA corpus
+// NOTE(danhollas): Those other commands are rare/non-existent in KA corpus
 var TEXT_REGEX = /\\text\s*{([^}]*)}/g;
 var TEXTBF_REGEX = /\\textbf\s*{([^}]*)}/g;
 
@@ -126,8 +126,7 @@ mathDictionary) {
     if (findRegex === MATH_REGEX) {
         inputs = inputs.map(function (input) {
             return translateMath(input, lang);
-        });
-        inputs = inputs.map(function (input) {
+        }).map(function (input) {
             return replaceTextInMath(input, mathDictionary);
         });
     }
@@ -135,14 +134,12 @@ mathDictionary) {
     var mapping = [];
 
     outputs.forEach(function (output, outputIndex) {
-        /*
-         * TODO(danielhollas): Should the following be here?
-         * i.e. should we automatically translate math even if translatedStr
-         * was not translated according to our locale rules?
-        if (findRegex === MATH_REGEX) {
-            output = translateMath(output, lang);
-        }
-        */
+
+        // NOTE(danielhollas): Currently, we will not offer smart translations
+        // if the user did not translate math according to our locale rules
+        // if (findRegex === MATH_REGEX) {
+        //     output = translateMath(output, lang);
+        // }
 
         var inputIndex = inputs.indexOf(output);
         if (inputIndex === -1) {
@@ -357,17 +354,19 @@ function createTemplate(englishStr, translatedStr, lang) {
 }
 
 /**
- * Handles any per language special case translations, e.g. Portuguese uses
- * `sen` instead of `sin`. Many lang use decimal comma.
- * According to this table:
+ * Handles any per language special case translations
+ * e.g. Portuguese uses `sen` instead of `sin`,
+ * many languages use decimal comma etc.
+ *
+ * The list of all per-locale math notations is in this table:
  * https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0
  *
  * TODO(danielhollas): For now only the obvious cases were implemented.
+ * TODO(danielhollas): Need to update this when new langs join translations
  *
  * @param {string} math A math expression to translate for locale.
  * @param {string} lang The locale of the translation language.
  * @returns {string} The translated math expression.
- * TODO(danielhollas): Need to update this when new langs join translations
  */
 function translateMath(math, lang) {
 

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -8,10 +8,6 @@
 // $\text{cost} = \$4$
 'use strict';
 
-var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
@@ -140,7 +136,7 @@ mathDictionary) {
 
     outputs.forEach(function (output, outputIndex) {
         // TODO(danielhollas): Should the following be here?
-        // Should we automatically translate math even if translatedStr
+        // i.e. should we automatically translate math even if translatedStr
         // was not translated according to our locale rules?
         //if (findRegex === MATH_REGEX) {
         //    output = translateMath(output, lang);
@@ -223,11 +219,9 @@ function getMathDictionary(englishStr, translatedStr) {
     inputs.forEach(function (input) {
         var normalized = input;
 
-        replaceRegexes.forEach(function (_ref) {
-            var _ref2 = _slicedToArray(_ref, 2);
-
-            var regex = _ref2[0];
-            var str = _ref2[1];
+        replaceRegexes.forEach(function (_ref3) {
+            var regex = _ref3[0];
+            var str = _ref3[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -241,11 +235,9 @@ function getMathDictionary(englishStr, translatedStr) {
     outputs.forEach(function (output) {
         var normalized = output;
 
-        replaceRegexes.forEach(function (_ref3) {
-            var _ref32 = _slicedToArray(_ref3, 2);
-
-            var regex = _ref32[0];
-            var str = _ref32[1];
+        replaceRegexes.forEach(function (_ref4) {
+            var regex = _ref4[0];
+            var str = _ref4[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -261,11 +253,9 @@ function getMathDictionary(englishStr, translatedStr) {
     var matchRegexes = [[/__TEXT__/, TEXT_REGEX], [/__TEXTBF__/, TEXTBF_REGEX]];
 
     Object.keys(inputMap).forEach(function (key) {
-        matchRegexes.forEach(function (_ref4) {
-            var _ref42 = _slicedToArray(_ref4, 2);
-
-            var match = _ref42[0];
-            var regex = _ref42[1];
+        matchRegexes.forEach(function (_ref5) {
+            var match = _ref5[0];
+            var regex = _ref5[1];
 
             if (match.test(key)) {
                 var _ret = (function () {
@@ -422,43 +412,34 @@ function replaceTextInMath(englishMath, dict) {
 
     var textCommands = ['text', 'textbf'];
 
-    var _iteratorNormalCompletion = true;
-    var _didIteratorError = false;
-    var _iteratorError = undefined;
-
-    try {
-        var _loop = function () {
-            var _step$value = _slicedToArray(_step.value, 2);
-
-            var englishText = _step$value[0];
-            var translatedText = _step$value[1];
-
-            textCommands.forEach(function (cmd) {
-                var regex = new RegExp('\\\\' + cmd + '(\\s*){' + englishText + '}', 'g');
-                // make sure the spacing matches in the replacement
-                var replacement = '\\' + cmd + '$1{' + translatedText + '}';
-                translatedMath = translatedMath.replace(regex, replacement);
-            });
-        };
-
-        for (var _iterator = Object.entries(dict)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-            _loop();
+    var _loop = function () {
+        if (_isArray) {
+            if (_i >= _iterator.length) return 'break';
+            _ref = _iterator[_i++];
+        } else {
+            _i = _iterator.next();
+            if (_i.done) return 'break';
+            _ref = _i.value;
         }
-    } catch (err) {
-        _didIteratorError = true;
-        _iteratorError = err;
-    } finally {
-        try {
-            if (!_iteratorNormalCompletion && _iterator['return']) {
-                _iterator['return']();
-            }
-        } finally {
-            if (_didIteratorError) {
-                throw _iteratorError;
-            }
-        }
+
+        var englishText = _ref[0];
+        var translatedText = _ref[1];
+
+        textCommands.forEach(function (cmd) {
+            var regex = new RegExp('\\\\' + cmd + '(\\s*){' + englishText + '}', 'g');
+            // make sure the spacing matches in the replacement
+            var replacement = '\\' + cmd + '$1{' + translatedText + '}';
+            translatedMath = translatedMath.replace(regex, replacement);
+        });
+    };
+
+    for (var _iterator = Object.entries(dict), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
+        var _ref;
+
+        var _ret2 = _loop();
+
+        if (_ret2 === 'break') break;
     }
-
     return translatedMath;
 }
 
@@ -596,153 +577,140 @@ var TranslationAssistant = (function () {
      * when passed one of the items.
      */
 
-    _createClass(TranslationAssistant, [{
-        key: 'suggest',
-        value: function suggest(itemsToTranslate) {
-            var _this = this;
+    TranslationAssistant.prototype.suggest = function suggest(itemsToTranslate) {
+        var _this = this;
 
-            var suggestionGroups = this.suggestionGroups;
-            var lang = this.lang;
+        var suggestionGroups = this.suggestionGroups;
+        var lang = this.lang;
 
-            return itemsToTranslate.map(function (item) {
-                var englishStr = rtrim(_this.getEnglishStr(item));
-                var normalStr = stringToGroupKey(englishStr);
-                var normalObj = JSON.parse(normalStr);
+        return itemsToTranslate.map(function (item) {
+            var englishStr = rtrim(_this.getEnglishStr(item));
+            var normalStr = stringToGroupKey(englishStr);
+            var normalObj = JSON.parse(normalStr);
 
-                // Translate items that are only math, a graphie, an image, or a
-                // widget.
-                // TODO(kevinb) handle multiple non-nl_text items
-                if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
-                    if (normalObj.str === '__MATH__') {
-                        // Only translate the math if it doesn't include any
-                        // natural language text in \text and \textbf commands.
-                        if (englishStr.indexOf('\\text') === -1) {
-                            return [item, translateMath(englishStr, lang)];
-                        }
-                    } else {
-                        return [item, englishStr];
+            // Translate items that are only math, a graphie, an image, or a
+            // widget.
+            // TODO(kevinb) handle multiple non-nl_text items
+            if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
+                if (normalObj.str === '__MATH__') {
+                    // Only translate the math if it doesn't include any
+                    // natural language text in \text and \textbf commands.
+                    if (englishStr.indexOf('\\text') === -1) {
+                        return [item, translateMath(englishStr, lang)];
                     }
-                }
-
-                if (suggestionGroups.hasOwnProperty(normalStr)) {
-                    var template = suggestionGroups[normalStr].template;
-
-                    // This error is probably due to math being different between
-                    // the English string and the translated string.
-                    if (template instanceof Error) {
-                        return [item, null];
-                    }
-
-                    if (template) {
-                        var translatedStr = populateTemplate(template, englishStr, lang);
-                        return [item, translatedStr];
-                    }
-                }
-
-                // The item doesn't belong in any of the suggestion groups.
-                return [item, null];
-            });
-        }
-
-        /**
-         * Group objects that contain English strings to translate.
-         *
-         * Groups are determined by the similarity between the English strings
-         * returned by `this.getEnglishStr` on each object in `items`.  In order to
-         * find more matches we ignore math, graphie, and widget substrings.
-         *
-         * Each group contains an array of items that belong in that group and a
-         * translation template if there was at least one item that had a
-         * translation.  Translations are determined by passing each item to
-         * `this.getTranslation`.
-         *
-         * Input:
-         * [
-         *    {
-         *        englishStr: "simplify $2/4$",
-         *        id: 1001,
-         *    }, {
-         *        englishStr: "simplify $3/12$",
-         *        id: 1002,
-         *    }
-         * ];
-         *
-         * Output:
-         * {
-         *    '{str:"simplify __MATH__",text:[[]]}': {
-         *        items: [{
-         *            englishStr: "simplify $2/4$",
-         *            id: 1001,
-         *        }, {
-         *            englishStr: "simplify $3/12$",
-         *            id: 1002,
-         *        }],
-         *        template: { ... }
-         *    },
-         *    ...
-         * }
-         *
-         * @param {Array<Object>} items The items with English strings to group.
-         * @returns {Object} A mapping of groups to items and translation template.
-         */
-    }, {
-        key: 'getSuggestionGroups',
-        value: function getSuggestionGroups(items) {
-            var _this2 = this;
-
-            var suggestionGroups = {};
-
-            items.forEach(function (obj) {
-                var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
-
-                if (suggestionGroups[key]) {
-                    suggestionGroups[key].push(obj);
                 } else {
-                    suggestionGroups[key] = [obj];
+                    return [item, englishStr];
                 }
-            });
+            }
 
-            Object.keys(suggestionGroups).forEach(function (key) {
-                var items = suggestionGroups[key];
+            if (suggestionGroups.hasOwnProperty(normalStr)) {
+                var template = suggestionGroups[normalStr].template;
 
-                var _iteratorNormalCompletion2 = true;
-                var _didIteratorError2 = false;
-                var _iteratorError2 = undefined;
-
-                try {
-                    for (var _iterator2 = items[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-                        var item = _step2.value;
-
-                        var englishStr = _this2.getEnglishStr(item);
-                        var translatedStr = _this2.getTranslation(item);
-
-                        if (translatedStr) {
-                            var template = createTemplate(englishStr, translatedStr, _this2.lang);
-                            suggestionGroups[key] = { items: items, template: template };
-                            return;
-                        }
-                    }
-                } catch (err) {
-                    _didIteratorError2 = true;
-                    _iteratorError2 = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion2 && _iterator2['return']) {
-                            _iterator2['return']();
-                        }
-                    } finally {
-                        if (_didIteratorError2) {
-                            throw _iteratorError2;
-                        }
-                    }
+                // This error is probably due to math being different between
+                // the English string and the translated string.
+                if (template instanceof Error) {
+                    return [item, null];
                 }
 
-                suggestionGroups[key] = { items: items, template: null };
-            });
+                if (template) {
+                    var translatedStr = populateTemplate(template, englishStr, lang);
+                    return [item, translatedStr];
+                }
+            }
 
-            return suggestionGroups;
-        }
-    }]);
+            // The item doesn't belong in any of the suggestion groups.
+            return [item, null];
+        });
+    };
+
+    /**
+     * Group objects that contain English strings to translate.
+     *
+     * Groups are determined by the similarity between the English strings
+     * returned by `this.getEnglishStr` on each object in `items`.  In order to
+     * find more matches we ignore math, graphie, and widget substrings.
+     *
+     * Each group contains an array of items that belong in that group and a
+     * translation template if there was at least one item that had a
+     * translation.  Translations are determined by passing each item to
+     * `this.getTranslation`.
+     *
+     * Input:
+     * [
+     *    {
+     *        englishStr: "simplify $2/4$",
+     *        id: 1001,
+     *    }, {
+     *        englishStr: "simplify $3/12$",
+     *        id: 1002,
+     *    }
+     * ];
+     *
+     * Output:
+     * {
+     *    '{str:"simplify __MATH__",text:[[]]}': {
+     *        items: [{
+     *            englishStr: "simplify $2/4$",
+     *            id: 1001,
+     *        }, {
+     *            englishStr: "simplify $3/12$",
+     *            id: 1002,
+     *        }],
+     *        template: { ... }
+     *    },
+     *    ...
+     * }
+     *
+     * @param {Array<Object>} items The items with English strings to group.
+     * @returns {Object} A mapping of groups to items and translation template.
+     */
+
+    TranslationAssistant.prototype.getSuggestionGroups = function getSuggestionGroups(items) {
+        var _this2 = this;
+
+        var suggestionGroups = {};
+
+        items.forEach(function (obj) {
+            var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
+
+            if (suggestionGroups[key]) {
+                suggestionGroups[key].push(obj);
+            } else {
+                suggestionGroups[key] = [obj];
+            }
+        });
+
+        Object.keys(suggestionGroups).forEach(function (key) {
+            var items = suggestionGroups[key];
+
+            for (var _iterator2 = items, _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : _iterator2[Symbol.iterator]();;) {
+                var _ref2;
+
+                if (_isArray2) {
+                    if (_i2 >= _iterator2.length) break;
+                    _ref2 = _iterator2[_i2++];
+                } else {
+                    _i2 = _iterator2.next();
+                    if (_i2.done) break;
+                    _ref2 = _i2.value;
+                }
+
+                var item = _ref2;
+
+                var englishStr = _this2.getEnglishStr(item);
+                var translatedStr = _this2.getTranslation(item);
+
+                if (translatedStr) {
+                    var template = createTemplate(englishStr, translatedStr, _this2.lang);
+                    suggestionGroups[key] = { items: items, template: template };
+                    return;
+                }
+            }
+            suggestionGroups[key] = { items: items, template: null };
+        });
+
+        return suggestionGroups;
+    };
 
     return TranslationAssistant;
 })();

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -8,6 +8,10 @@
 // $\text{cost} = \$4$
 'use strict';
 
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
@@ -26,6 +30,7 @@ var WIDGET_REGEX = /\[\[[\u2603][^\]]+\]\]/g;
 
 // TODO(michaelpolyak): Add support for other \text commands:
 // https://github.com/Khan/KaTeX/blob/3280652bd68973ad9edd73273137049324c5cab9/src/functions.js#L50
+// Comment(danhollas): Those other commands are rare/non-existent in KA corpus
 var TEXT_REGEX = /\\text\s*{([^}]*)}/g;
 var TEXTBF_REGEX = /\\textbf\s*{([^}]*)}/g;
 
@@ -124,6 +129,9 @@ mathDictionary) {
 
     if (findRegex === MATH_REGEX) {
         inputs = inputs.map(function (input) {
+            return translateMath(input, lang);
+        });
+        inputs = inputs.map(function (input) {
             return replaceTextInMath(input, mathDictionary);
         });
     }
@@ -131,6 +139,9 @@ mathDictionary) {
     var mapping = [];
 
     outputs.forEach(function (output, outputIndex) {
+        // TODO(danielhollas): Should the following be here?
+        // e.g. should we automatically translate to decimal commas
+        // even if original string was not?
         if (findRegex === MATH_REGEX) {
             output = translateMath(output, lang);
         }
@@ -212,9 +223,11 @@ function getMathDictionary(englishStr, translatedStr) {
     inputs.forEach(function (input) {
         var normalized = input;
 
-        replaceRegexes.forEach(function (_ref3) {
-            var regex = _ref3[0];
-            var str = _ref3[1];
+        replaceRegexes.forEach(function (_ref) {
+            var _ref2 = _slicedToArray(_ref, 2);
+
+            var regex = _ref2[0];
+            var str = _ref2[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -228,9 +241,11 @@ function getMathDictionary(englishStr, translatedStr) {
     outputs.forEach(function (output) {
         var normalized = output;
 
-        replaceRegexes.forEach(function (_ref4) {
-            var regex = _ref4[0];
-            var str = _ref4[1];
+        replaceRegexes.forEach(function (_ref3) {
+            var _ref32 = _slicedToArray(_ref3, 2);
+
+            var regex = _ref32[0];
+            var str = _ref32[1];
 
             normalized = normalized.replace(regex, str);
         });
@@ -246,9 +261,11 @@ function getMathDictionary(englishStr, translatedStr) {
     var matchRegexes = [[/__TEXT__/, TEXT_REGEX], [/__TEXTBF__/, TEXTBF_REGEX]];
 
     Object.keys(inputMap).forEach(function (key) {
-        matchRegexes.forEach(function (_ref5) {
-            var match = _ref5[0];
-            var regex = _ref5[1];
+        matchRegexes.forEach(function (_ref4) {
+            var _ref42 = _slicedToArray(_ref4, 2);
+
+            var match = _ref42[0];
+            var regex = _ref42[1];
 
             if (match.test(key)) {
                 var _ret = (function () {
@@ -351,13 +368,32 @@ function createTemplate(englishStr, translatedStr, lang) {
  * @returns {string} The translated math expression.
  *
  * TODO(kevinb): handle \text{} inside math.
+ * TODO(danielhollas): implement locale specific translations according to:
+ * https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0
  */
 function translateMath(math, lang) {
-    if (lang === 'pt') {
-        return math.replace(/\\sin/g, '\\operatorname\{sen\}');
-    } else {
-        return math;
-    }
+
+    var mathTranslations = [
+    // division sign as a colon
+    { langs: ['cs'],
+        regex: /\\div/g, replace: '\\mathbin{:}' },
+    // latin trig functions
+    { langs: ['es', 'it', 'pt', 'pt-pt'],
+        regex: /\\sin/g, replace: '\\operatorname\{sen\}' },
+    // Decimal comma
+    { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it'],
+        regex: /([0-9]).([0-9])/g, replace: '$1{,}$2' },
+    // multiplication sign as a dot
+    { langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu'],
+        regex: /\\mult/g, replace: '\\cdot' }];
+
+    mathTranslations.forEach(function (element) {
+        if (element.langs.includes(lang)) {
+            math = math.replace(element.regex, element.replace);
+        }
+    });
+
+    return math;
 }
 
 /**
@@ -385,34 +421,43 @@ function replaceTextInMath(englishMath, dict) {
 
     var textCommands = ['text', 'textbf'];
 
-    var _loop = function () {
-        if (_isArray) {
-            if (_i >= _iterator.length) return 'break';
-            _ref = _iterator[_i++];
-        } else {
-            _i = _iterator.next();
-            if (_i.done) return 'break';
-            _ref = _i.value;
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+        var _loop = function () {
+            var _step$value = _slicedToArray(_step.value, 2);
+
+            var englishText = _step$value[0];
+            var translatedText = _step$value[1];
+
+            textCommands.forEach(function (cmd) {
+                var regex = new RegExp('\\\\' + cmd + '(\\s*){' + englishText + '}', 'g');
+                // make sure the spacing matches in the replacement
+                var replacement = '\\' + cmd + '$1{' + translatedText + '}';
+                translatedMath = translatedMath.replace(regex, replacement);
+            });
+        };
+
+        for (var _iterator = Object.entries(dict)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            _loop();
         }
-
-        var englishText = _ref[0];
-        var translatedText = _ref[1];
-
-        textCommands.forEach(function (cmd) {
-            var regex = new RegExp('\\\\' + cmd + '(\\s*){' + englishText + '}', 'g');
-            // make sure the spacing matches in the replacement
-            var replacement = '\\' + cmd + '$1{' + translatedText + '}';
-            translatedMath = translatedMath.replace(regex, replacement);
-        });
-    };
-
-    for (var _iterator = Object.entries(dict), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
-        var _ref;
-
-        var _ret2 = _loop();
-
-        if (_ret2 === 'break') break;
+    } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion && _iterator['return']) {
+                _iterator['return']();
+            }
+        } finally {
+            if (_didIteratorError) {
+                throw _iteratorError;
+            }
+        }
     }
+
     return translatedMath;
 }
 
@@ -510,10 +555,10 @@ var TranslationAssistant = (function () {
     function TranslationAssistant(allItems, getEnglishStr, getTranslation, lang) {
         _classCallCheck(this, TranslationAssistant);
 
+        this.lang = lang;
         this.getEnglishStr = getEnglishStr;
         this.getTranslation = getTranslation;
         this.suggestionGroups = this.getSuggestionGroups(allItems);
-        this.lang = lang;
     }
 
     /**
@@ -550,140 +595,153 @@ var TranslationAssistant = (function () {
      * when passed one of the items.
      */
 
-    TranslationAssistant.prototype.suggest = function suggest(itemsToTranslate) {
-        var _this = this;
+    _createClass(TranslationAssistant, [{
+        key: 'suggest',
+        value: function suggest(itemsToTranslate) {
+            var _this = this;
 
-        var suggestionGroups = this.suggestionGroups;
-        var lang = this.lang;
+            var suggestionGroups = this.suggestionGroups;
+            var lang = this.lang;
 
-        return itemsToTranslate.map(function (item) {
-            var englishStr = rtrim(_this.getEnglishStr(item));
-            var normalStr = stringToGroupKey(englishStr);
-            var normalObj = JSON.parse(normalStr);
+            return itemsToTranslate.map(function (item) {
+                var englishStr = rtrim(_this.getEnglishStr(item));
+                var normalStr = stringToGroupKey(englishStr);
+                var normalObj = JSON.parse(normalStr);
 
-            // Translate items that are only math, a graphie, an image, or a
-            // widget.
-            // TODO(kevinb) handle multiple non-nl_text items
-            if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
-                if (normalObj.str === '__MATH__') {
-                    // Only translate the math if it doesn't include any
-                    // natural language text in \text and \textbf commands.
-                    if (englishStr.indexOf('\\text') === -1) {
-                        return [item, translateMath(englishStr, lang)];
+                // Translate items that are only math, a graphie, an image, or a
+                // widget.
+                // TODO(kevinb) handle multiple non-nl_text items
+                if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
+                    if (normalObj.str === '__MATH__') {
+                        // Only translate the math if it doesn't include any
+                        // natural language text in \text and \textbf commands.
+                        if (englishStr.indexOf('\\text') === -1) {
+                            return [item, translateMath(englishStr, lang)];
+                        }
+                    } else {
+                        return [item, englishStr];
                     }
+                }
+
+                if (suggestionGroups.hasOwnProperty(normalStr)) {
+                    var template = suggestionGroups[normalStr].template;
+
+                    // This error is probably due to math being different between
+                    // the English string and the translated string.
+                    if (template instanceof Error) {
+                        return [item, null];
+                    }
+
+                    if (template) {
+                        var translatedStr = populateTemplate(template, englishStr, lang);
+                        return [item, translatedStr];
+                    }
+                }
+
+                // The item doesn't belong in any of the suggestion groups.
+                return [item, null];
+            });
+        }
+
+        /**
+         * Group objects that contain English strings to translate.
+         *
+         * Groups are determined by the similarity between the English strings
+         * returned by `this.getEnglishStr` on each object in `items`.  In order to
+         * find more matches we ignore math, graphie, and widget substrings.
+         *
+         * Each group contains an array of items that belong in that group and a
+         * translation template if there was at least one item that had a
+         * translation.  Translations are determined by passing each item to
+         * `this.getTranslation`.
+         *
+         * Input:
+         * [
+         *    {
+         *        englishStr: "simplify $2/4$",
+         *        id: 1001,
+         *    }, {
+         *        englishStr: "simplify $3/12$",
+         *        id: 1002,
+         *    }
+         * ];
+         *
+         * Output:
+         * {
+         *    '{str:"simplify __MATH__",text:[[]]}': {
+         *        items: [{
+         *            englishStr: "simplify $2/4$",
+         *            id: 1001,
+         *        }, {
+         *            englishStr: "simplify $3/12$",
+         *            id: 1002,
+         *        }],
+         *        template: { ... }
+         *    },
+         *    ...
+         * }
+         *
+         * @param {Array<Object>} items The items with English strings to group.
+         * @returns {Object} A mapping of groups to items and translation template.
+         */
+    }, {
+        key: 'getSuggestionGroups',
+        value: function getSuggestionGroups(items) {
+            var _this2 = this;
+
+            var suggestionGroups = {};
+
+            items.forEach(function (obj) {
+                var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
+
+                if (suggestionGroups[key]) {
+                    suggestionGroups[key].push(obj);
                 } else {
-                    return [item, englishStr];
+                    suggestionGroups[key] = [obj];
                 }
-            }
+            });
 
-            if (suggestionGroups.hasOwnProperty(normalStr)) {
-                var template = suggestionGroups[normalStr].template;
+            Object.keys(suggestionGroups).forEach(function (key) {
+                var items = suggestionGroups[key];
 
-                // This error is probably due to math being different between
-                // the English string and the translated string.
-                if (template instanceof Error) {
-                    return [item, null];
-                }
+                var _iteratorNormalCompletion2 = true;
+                var _didIteratorError2 = false;
+                var _iteratorError2 = undefined;
 
-                if (template) {
-                    var translatedStr = populateTemplate(template, englishStr, lang);
-                    return [item, translatedStr];
-                }
-            }
+                try {
+                    for (var _iterator2 = items[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                        var item = _step2.value;
 
-            // The item doesn't belong in any of the suggestion groups.
-            return [item, null];
-        });
-    };
+                        var englishStr = _this2.getEnglishStr(item);
+                        var translatedStr = _this2.getTranslation(item);
 
-    /**
-     * Group objects that contain English strings to translate.
-     *
-     * Groups are determined by the similarity between the English strings
-     * returned by `this.getEnglishStr` on each object in `items`.  In order to
-     * find more matches we ignore math, graphie, and widget substrings.
-     *
-     * Each group contains an array of items that belong in that group and a
-     * translation template if there was at least one item that had a
-     * translation.  Translations are determined by passing each item to
-     * `this.getTranslation`.
-     *
-     * Input:
-     * [
-     *    {
-     *        englishStr: "simplify $2/4$",
-     *        id: 1001,
-     *    }, {
-     *        englishStr: "simplify $3/12$",
-     *        id: 1002,
-     *    }
-     * ];
-     *
-     * Output:
-     * {
-     *    '{str:"simplify __MATH__",text:[[]]}': {
-     *        items: [{
-     *            englishStr: "simplify $2/4$",
-     *            id: 1001,
-     *        }, {
-     *            englishStr: "simplify $3/12$",
-     *            id: 1002,
-     *        }],
-     *        template: { ... }
-     *    },
-     *    ...
-     * }
-     *
-     * @param {Array<Object>} items The items with English strings to group.
-     * @returns {Object} A mapping of groups to items and translation template.
-     */
-
-    TranslationAssistant.prototype.getSuggestionGroups = function getSuggestionGroups(items) {
-        var _this2 = this;
-
-        var suggestionGroups = {};
-
-        items.forEach(function (obj) {
-            var key = stringToGroupKey(rtrim(_this2.getEnglishStr(obj)));
-
-            if (suggestionGroups[key]) {
-                suggestionGroups[key].push(obj);
-            } else {
-                suggestionGroups[key] = [obj];
-            }
-        });
-
-        Object.keys(suggestionGroups).forEach(function (key) {
-            var items = suggestionGroups[key];
-
-            for (var _iterator2 = items, _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : _iterator2[Symbol.iterator]();;) {
-                var _ref2;
-
-                if (_isArray2) {
-                    if (_i2 >= _iterator2.length) break;
-                    _ref2 = _iterator2[_i2++];
-                } else {
-                    _i2 = _iterator2.next();
-                    if (_i2.done) break;
-                    _ref2 = _i2.value;
+                        if (translatedStr) {
+                            var template = createTemplate(englishStr, translatedStr, _this2.lang);
+                            suggestionGroups[key] = { items: items, template: template };
+                            return;
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError2 = true;
+                    _iteratorError2 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion2 && _iterator2['return']) {
+                            _iterator2['return']();
+                        }
+                    } finally {
+                        if (_didIteratorError2) {
+                            throw _iteratorError2;
+                        }
+                    }
                 }
 
-                var item = _ref2;
+                suggestionGroups[key] = { items: items, template: null };
+            });
 
-                var englishStr = _this2.getEnglishStr(item);
-                var translatedStr = _this2.getTranslation(item);
-
-                if (translatedStr) {
-                    var template = createTemplate(englishStr, translatedStr, _this2.lang);
-                    suggestionGroups[key] = { items: items, template: template };
-                    return;
-                }
-            }
-            suggestionGroups[key] = { items: items, template: null };
-        });
-
-        return suggestionGroups;
-    };
+            return suggestionGroups;
+        }
+    }]);
 
     return TranslationAssistant;
 })();

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -135,12 +135,14 @@ mathDictionary) {
     var mapping = [];
 
     outputs.forEach(function (output, outputIndex) {
-        // TODO(danielhollas): Should the following be here?
-        // i.e. should we automatically translate math even if translatedStr
-        // was not translated according to our locale rules?
-        //if (findRegex === MATH_REGEX) {
-        //    output = translateMath(output, lang);
-        //}
+        /*
+         * TODO(danielhollas): Should the following be here?
+         * i.e. should we automatically translate math even if translatedStr
+         * was not translated according to our locale rules?
+        if (findRegex === MATH_REGEX) {
+            output = translateMath(output, lang);
+        }
+        */
 
         var inputIndex = inputs.indexOf(output);
         if (inputIndex === -1) {
@@ -202,12 +204,13 @@ function allMatches(text, regex, callback) {
  *
  * @param {String} englishStr The English source string.
  * @param {String} translatedStr The translation of the englishStr.
+ * @param {String} lang Locale, needed for Math translation.
  * @returns {Object} The English to translated string mapping for strings inside
  *          \text{} and \textbf{} blocks.
  *
  * TODO(kevinb): automatically handle \text{} blocks containing numbers only.
  */
-function getMathDictionary(englishStr, translatedStr) {
+function getMathDictionary(englishStr, translatedStr, lang) {
     var inputs = englishStr.match(MATH_REGEX) || [];
     var outputs = translatedStr.match(MATH_REGEX) || [];
 
@@ -215,6 +218,10 @@ function getMathDictionary(englishStr, translatedStr) {
     var outputMap = {};
 
     var replaceRegexes = [[TEXT_REGEX, '__TEXT__'], [TEXTBF_REGEX, '__TEXTBF__']];
+
+    inputs = inputs.map(function (input) {
+        return translateMath(input, lang);
+    });
 
     inputs.forEach(function (input) {
         var normalized = input;
@@ -324,8 +331,8 @@ function createTemplate(englishStr, translatedStr, lang) {
     englishStr = rtrim(englishStr);
     translatedStr = rtrim(translatedStr);
     var translatedLines = translatedStr.split(LINE_BREAK);
-    var englishDictionary = getMathDictionary(englishStr, englishStr);
-    var translatedDictionary = getMathDictionary(englishStr, translatedStr);
+    var englishDictionary = getMathDictionary(englishStr, englishStr, lang);
+    var translatedDictionary = getMathDictionary(englishStr, translatedStr, lang);
 
     try {
         return {
@@ -366,7 +373,7 @@ function translateMath(math, lang) {
 
     var mathTranslations = [
     // division sign as a colon
-    { langs: ['cs'],
+    { langs: ['cs', 'de'],
         regex: /\\div/g, replace: '\\mathbin{:}' },
     // latin trig functions
     { langs: ['es', 'it', 'pt', 'pt-pt'],
@@ -467,7 +474,7 @@ function populateTemplate(template, englishStr, lang) {
     if (template.mathMapping.englishToTranslated.length) {
         // To that end we create an English to English math mapping for this
         // string.
-        var englishDictionary = getMathDictionary(englishStr, englishStr);
+        var englishDictionary = getMathDictionary(englishStr, englishStr, lang);
         var englishMapping = getMapping(englishStr, englishStr, 'en', MATH_REGEX, englishDictionary);
         // And verify that the math mapping is identical to the one in the
         // template.

--- a/package.json
+++ b/package.json
@@ -6,20 +6,20 @@
   "scripts": {
     "lint": "eslint src tests",
     "test": "mocha --compilers js:babel/register tests",
-    "build": "babel --loose src/translation-assistant.js -o lib/translation-assistant.js",
+    "build": "babel src/translation-assistant.js -o lib/translation-assistant.js",
     "watch_test": "mocha --watch --compilers js:babel/register tests",
-    "watch_build": "babel --loose --watch src/translation-assistant.js -o lib/translation-assistant.js"
+    "watch_build": "babel --watch src/translation-assistant.js -o lib/translation-assistant.js"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Khan/intelligent-tm"
+    "url": "https://github.com/Khan/translation-assistant"
   },
   "author": "Kevin Barabash <kevinbarabash@khanacademy.org>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Khan/intelligent-tm/issues"
   },
-  "homepage": "https://github.com/Khan/intelligent-tm",
+  "homepage": "https://github.com/Khan/translation-assistant",
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "lint": "eslint src tests",
     "test": "mocha --compilers js:babel/register tests",
-    "build": "babel src/translation-assistant.js -o lib/translation-assistant.js",
+    "build": "babel --loose src/translation-assistant.js -o lib/translation-assistant.js",
     "watch_test": "mocha --watch --compilers js:babel/register tests",
-    "watch_build": "babel --watch src/translation-assistant.js -o lib/translation-assistant.js"
+    "watch_build": "babel --loose --watch src/translation-assistant.js -o lib/translation-assistant.js"
   },
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "author": "Kevin Barabash <kevinbarabash@khanacademy.org>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Khan/intelligent-tm/issues"
+    "url": "https://github.com/Khan/translation-assistant/issues"
   },
   "homepage": "https://github.com/Khan/translation-assistant",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "lint": "eslint src tests",
     "test": "mocha --compilers js:babel/register tests",
-    "build": "babel --loose src/translation-assistant.js -o lib/translation-assistant.js",
+    "build": "babel --loose all src/translation-assistant.js -o lib/translation-assistant.js",
     "watch_test": "mocha --watch --compilers js:babel/register tests",
-    "watch_build": "babel --loose --watch src/translation-assistant.js -o lib/translation-assistant.js"
+    "watch_build": "babel --loose all --watch src/translation-assistant.js -o lib/translation-assistant.js"
   },
   "repository": {
     "type": "git",

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -140,11 +140,11 @@ function getMapping(
 
     outputs.forEach((output, outputIndex) => {
         // TODO(danielhollas): Should the following be here?
-        // e.g. should we automatically translate to decimal commas
-        // even if original string was not?
-        if (findRegex === MATH_REGEX) {
-            output = translateMath(output, lang);
-        }
+        // Should we automatically translate math even if translatedStr 
+        // was not translated according to our locale rules?
+        //if (findRegex === MATH_REGEX) {
+        //    output = translateMath(output, lang);
+        //}
 
         const inputIndex = inputs.indexOf(output);
         if (inputIndex === -1) {
@@ -354,15 +354,16 @@ function createTemplate(englishStr, translatedStr, lang) {
 
 /**
  * Handles any per language special case translations, e.g. Portuguese uses
- * `sen` instead of `sin`.
+ * `sen` instead of `sin`. Many lang use decimal comma.
+ * According to this table:
+ * https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0
+ *
+ * TODO(danielhollas): For now only the obvious cases were implemented.
  *
  * @param {string} math A math expression to translate for locale.
  * @param {string} lang The locale of the translation language.
  * @returns {string} The translated math expression.
- *
- * TODO(kevinb): handle \text{} inside math.
- * TODO(danielhollas): implement locale specific translations according to:
- * https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0
+ * TODO(danielhollas): Need to update this when new langs join translations
  */
 function translateMath(math, lang) {
 

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -23,7 +23,7 @@ const WIDGET_REGEX = /\[\[[\u2603][^\]]+\]\]/g;
 
 // TODO(michaelpolyak): Add support for other \text commands:
 // https://github.com/Khan/KaTeX/blob/3280652bd68973ad9edd73273137049324c5cab9/src/functions.js#L50
-// Comment(danhollas): Those other commands are rare/non-existent in KA corpus
+// NOTE(danhollas): Those other commands are rare/non-existent in KA corpus
 const TEXT_REGEX = /\\text\s*{([^}]*)}/g;
 const TEXTBF_REGEX = /\\textbf\s*{([^}]*)}/g;
 
@@ -130,23 +130,20 @@ function getMapping(
     const outputs = translatedStr.match(findRegex) || [];
 
     if (findRegex === MATH_REGEX) {
-        inputs = inputs.map(
-            (input) => translateMath(input, lang));
-        inputs = inputs.map(
-            (input) => replaceTextInMath(input, mathDictionary));
+        inputs = inputs
+            .map((input) => translateMath(input, lang))
+            .map((input) => replaceTextInMath(input, mathDictionary));
     }
 
     const mapping = [];
 
     outputs.forEach((output, outputIndex) => {
-        /*
-         * TODO(danielhollas): Should the following be here?
-         * i.e. should we automatically translate math even if translatedStr
-         * was not translated according to our locale rules?
-        if (findRegex === MATH_REGEX) {
-            output = translateMath(output, lang);
-        }
-        */
+
+        // NOTE(danielhollas): Currently, we will not offer smart translations
+        // if the user did not translate math according to our locale rules
+        // if (findRegex === MATH_REGEX) {
+        //     output = translateMath(output, lang);
+        // }
 
         const inputIndex = inputs.indexOf(output);
         if (inputIndex === -1) {
@@ -360,17 +357,19 @@ function createTemplate(englishStr, translatedStr, lang) {
 }
 
 /**
- * Handles any per language special case translations, e.g. Portuguese uses
- * `sen` instead of `sin`. Many lang use decimal comma.
- * According to this table:
+ * Handles any per language special case translations
+ * e.g. Portuguese uses `sen` instead of `sin`,
+ * many languages use decimal comma etc.
+ *
+ * The list of all per-locale math notations is in this table:
  * https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0
  *
  * TODO(danielhollas): For now only the obvious cases were implemented.
+ * TODO(danielhollas): Need to update this when new langs join translations
  *
  * @param {string} math A math expression to translate for locale.
  * @param {string} lang The locale of the translation language.
  * @returns {string} The translated math expression.
- * TODO(danielhollas): Need to update this when new langs join translations
  */
 function translateMath(math, lang) {
 

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -140,7 +140,7 @@ function getMapping(
 
     outputs.forEach((output, outputIndex) => {
         // TODO(danielhollas): Should the following be here?
-        // Should we automatically translate math even if translatedStr 
+        // i.e. should we automatically translate math even if translatedStr
         // was not translated according to our locale rules?
         //if (findRegex === MATH_REGEX) {
         //    output = translateMath(output, lang);

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -62,7 +62,7 @@ const graphieLink6 = makeGraphieLink();
 
 const getEnglishStr = (item) => item.englishStr;
 const getTranslation = (item) => item.translatedStr;
-const lang = 'fr';
+const lang = 'cs';
 
 /**
  * Assert that the suggested translations match the translations.
@@ -76,9 +76,10 @@ const lang = 'fr';
  *        there is no suggested translation expected for the item.
  * @returns {void}
  */
-function assertSuggestions(allItems, itemsToTranslate, translatedStrs) {
+function assertSuggestions(allItems, itemsToTranslate, translatedStrs,
+        lg = lang) {
     const assistant =
-        new TranslationAssistant(allItems, getEnglishStr, getTranslation, lang);
+        new TranslationAssistant(allItems, getEnglishStr, getTranslation, lg);
 
     const suggestions = assistant.suggest(itemsToTranslate);
 
@@ -475,6 +476,102 @@ describe('TranslationAssistant (math)', function() {
         const translatedStrs = [null];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+    });
+});
+
+//TODO(danielhollas): Add more tests various locales
+describe('TranslationAssistant (math-translate)', function() {
+    it('should translate decimal point to comma for fr locale', function() {
+        const lang = 'fr';
+        const allItems = [{
+            englishStr: 'simplify $2.3$',
+            translatedStr: 'simplifyz $2{,}3$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $2.9$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['simplifyz $2{,}9$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    // TODO(danielhollas):This we need to decide
+    /*
+    it('should not translate decimal point if not in translation?', function() {
+        const lang = 'fr';
+        const allItems = [{
+            englishStr: 'simplify $2.3$',
+            translatedStr: 'simplifyz $2.3$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $2.9$',
+            translatedStr: '',
+        }];
+        const translatedStrs = [null];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+    */
+
+    it('should not translate decimal point to comma for ko', function() {
+        const lang = 'ko';
+        const allItems = [{
+            englishStr: 'simplify $2.3$',
+            translatedStr: 'simplifyz $2{,}3$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $2.9$',
+            translatedStr: '',
+        }];
+        const translatedStrs = [null];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    it('should translate \\mult to \\cdot for cs locale', function() {
+        const lang = 'cs';
+        const allItems = [{
+            englishStr: 'simplify $2 \\mult 3$',
+            translatedStr: 'simplifyz $2 \\cdot 3$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $2 \\mult 9$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['simplifyz $2 \\cdot 9$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    it('should translate \\div to \\mathbin{:} for cs locale', function() {
+        const lang = 'cs';
+        const allItems = [{
+            englishStr: 'simplify $2 \\div 3$',
+            translatedStr: 'simplifyz $2 \\mathbin{:} 3$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $2 \\div 9$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['simplifyz $2 \\mathbin{:} 9$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    it('should translate \\sin to \\sen for pt locale', function() {
+        const lang = 'pt';
+        const allItems = [{
+            englishStr: 'from $\\sin \\theta$ to $3$',
+            translatedStr: 'fromy $\\operatorname{sen} \\theta$ till $3$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'from $\\sin \\theta$ to $5$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['fromy $\\operatorname{sen} \\theta$ till $5$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
 });
 

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -479,7 +479,6 @@ describe('TranslationAssistant (math)', function() {
     });
 });
 
-//TODO(danielhollas): Add more tests various locales
 describe('TranslationAssistant (math-translate)', function() {
     it('should translate decimal point to comma for fr locale', function() {
         const lang = 'fr';
@@ -494,6 +493,87 @@ describe('TranslationAssistant (math-translate)', function() {
         const translatedStrs = ['simplifyz $2{,}9$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    it('should translate math alone', function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3 \\mult x = 9.9$', translatedStr: ''},
+            {englishStr: 'hello', translatedStr: ''},
+        ];
+        const translatedStrs = ['$3 \\cdot x = 9{,}9$', null];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'cs');
+    });
+
+    it('should translate multiple math notations at once', function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3 \\mult x = 9.9 \\div 3$', translatedStr: ''},
+        ];
+        const translatedStrs = ['$3 \\cdot x = 9{,}9 \\mathbin{:} 3$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'de');
+    });
+
+    it('should translate multiple decimals', function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3 \\mult x = 9.9 \\div 3.3$', translatedStr: ''},
+        ];
+        const translatedStrs = ['$3 \\cdot x = 9{,}9 \\mathbin{:} 3{,}3$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'de');
+    });
+
+    it('should translate math with \\text', function() {
+        const allItems = [{
+            englishStr: 'simplify $\\text{red} = 5.1$',
+            translatedStr: 'simplifyz $\\text{rouge} = 5{,}1$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $3 * \\text{red} = 20.4$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['simplifyz $3 * \\text{rouge} = 20{,}4$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'fr');
+    });
+
+    it('should translate math with \\textbf', function() {
+        const allItems = [{
+            englishStr: 'simplify $\\textbf{red} = 5.1$',
+            translatedStr: 'simplifyz $\\textbf{rouge} = 5{,}1$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $3 * \\textbf{red} = 20.4$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['simplifyz $3 * \\textbf{rouge} = 20{,}4$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'fr');
+    });
+
+    it('should translate math with \\text{} and \\textbf{}', function() {
+        const allItems = [{
+            englishStr: 'simplify $\\text{red} = 5 \\mult \\textbf{blue}$',
+            translatedStr: 'simplifyz $\\text{azul} = 5 \\cdot \\textbf{roja}$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $3 \\text{red} = 2 \\div \\textbf{blue}$',
+            translatedStr: '',
+        }, {
+            englishStr: 'simplify $3 \\textbf{red} = 2 \\div \\text{blue}$',
+            translatedStr: '',
+        }];
+
+        // Even though "red" in Spanish should be "roja", smart translations
+        // doesn't know that.  The template built from allItems will contain a
+        // mathDictionary which maps "red" to "azul" and "blue" to "roja".
+        assertSuggestions(allItems, itemsToTranslate, [
+            'simplifyz $3 \\text{azul} = 2 \\mathbin{:} \\textbf{roja}$',
+            'simplifyz $3 \\textbf{azul} = 2 \\mathbin{:} \\text{roja}$',
+        ], 'cs');
     });
 
     // TODO(danielhollas): This we need to decide
@@ -531,29 +611,29 @@ describe('TranslationAssistant (math-translate)', function() {
     it('should translate \\mult to \\cdot for cs locale', function() {
         const lang = 'cs';
         const allItems = [{
-            englishStr: 'simplify $2 \\mult 3$',
-            translatedStr: 'simplifyz $2 \\cdot 3$',
+            englishStr: 'simplify $2 \\mult 3 \\mult 2$',
+            translatedStr: 'simplifyz $2 \\cdot 3 \\cdot 2$',
         }];
         const itemsToTranslate = [{
-            englishStr: 'simplify $2 \\mult 9$',
+            englishStr: 'simplify $2 \\mult 9 \\mult 9$',
             translatedStr: '',
         }];
-        const translatedStrs = ['simplifyz $2 \\cdot 9$'];
+        const translatedStrs = ['simplifyz $2 \\cdot 9 \\cdot 9$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
 
-    it('should translate \\div to \\mathbin{:} for cs locale', function() {
-        const lang = 'cs';
+    it('should translate \\div to \\mathbin{:} for de locale', function() {
+        const lang = 'de';
         const allItems = [{
             englishStr: 'simplify $2 \\div 3$',
             translatedStr: 'simplifyz $2 \\mathbin{:} 3$',
         }];
         const itemsToTranslate = [{
-            englishStr: 'simplify $2 \\div 9$',
+            englishStr: 'simplify $2 \\div 9 \\div 3$',
             translatedStr: '',
         }];
-        const translatedStrs = ['simplifyz $2 \\mathbin{:} 9$'];
+        const translatedStrs = ['simplifyz $2 \\mathbin{:} 9 \\mathbin{:} 3$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
@@ -561,14 +641,15 @@ describe('TranslationAssistant (math-translate)', function() {
     it('should translate \\sin to \\sen for pt locale', function() {
         const lang = 'pt';
         const allItems = [{
-            englishStr: 'from $\\sin \\theta$ to $3$',
-            translatedStr: 'fromy $\\operatorname{sen} \\theta$ till $3$',
+            englishStr: 'from $\\sin \\theta$ to $3\\sin$',
+            translatedStr: 'fr $\\operatorname{sen} \\theta$ till ' +
+                           '$3\\operatorname{sen}$',
         }];
         const itemsToTranslate = [{
             englishStr: 'from $\\sin \\theta$ to $5$',
             translatedStr: '',
         }];
-        const translatedStrs = ['fromy $\\operatorname{sen} \\theta$ till $5$'];
+        const translatedStrs = ['fr $\\operatorname{sen} \\theta$ till $5$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -496,10 +496,9 @@ describe('TranslationAssistant (math-translate)', function() {
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
 
-    // TODO(danielhollas):This we need to decide
-    /*
-    it('should not translate decimal point if not in translation?', function() {
-        const lang = 'fr';
+    // TODO(danielhollas): This we need to decide
+    it('should not offer translations of math is not translated properly', function() {
+        const lang = 'cs';
         const allItems = [{
             englishStr: 'simplify $2.3$',
             translatedStr: 'simplifyz $2.3$',
@@ -509,10 +508,10 @@ describe('TranslationAssistant (math-translate)', function() {
             translatedStr: '',
         }];
         const translatedStrs = [null];
+        //const translatedStrs = ['simplifyz $2{,}9$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
-    */
 
     it('should not translate decimal point to comma for ko', function() {
         const lang = 'ko';

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -497,7 +497,7 @@ describe('TranslationAssistant (math-translate)', function() {
     });
 
     // TODO(danielhollas): This we need to decide
-    it('should not offer translations of math is not translated properly', function() {
+    it('should not suggest ST if math is not translated properly', function() {
         const lang = 'cs';
         const allItems = [{
             englishStr: 'simplify $2.3$',

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -62,7 +62,6 @@ const graphieLink6 = makeGraphieLink();
 
 const getEnglishStr = (item) => item.englishStr;
 const getTranslation = (item) => item.translatedStr;
-const lang = 'cs';
 
 /**
  * Assert that the suggested translations match the translations.
@@ -74,12 +73,13 @@ const lang = 'cs';
  * @param {Array<String|null>} translatedStrs List of the expected translated
  *        strings for items, if an expected translation is `null` it means that
  *        there is no suggested translation expected for the item.
+ * @param {String} lang Locale for translation of math notation
  * @returns {void}
  */
 function assertSuggestions(allItems, itemsToTranslate, translatedStrs,
-        lg = lang) {
+        lang = 'cs') {
     const assistant =
-        new TranslationAssistant(allItems, getEnglishStr, getTranslation, lg);
+        new TranslationAssistant(allItems, getEnglishStr, getTranslation, lang);
 
     const suggestions = assistant.suggest(itemsToTranslate);
 
@@ -407,7 +407,7 @@ describe('TranslationAssistant (math)', function() {
         }];
 
         const assistant = new TranslationAssistant(
-            allItems, getEnglishStr, getTranslation, lang);
+            allItems, getEnglishStr, getTranslation);
 
         const translation = assistant.suggest(itemsToTranslate);
         assert.equal(translation[0][1], null);
@@ -481,7 +481,6 @@ describe('TranslationAssistant (math)', function() {
 
 describe('TranslationAssistant (math-translate)', function() {
     it('should translate decimal point to comma for fr locale', function() {
-        const lang = 'fr';
         const allItems = [{
             englishStr: 'simplify $2.3$',
             translatedStr: 'simplifyz $2{,}3$',
@@ -492,7 +491,7 @@ describe('TranslationAssistant (math-translate)', function() {
         }];
         const translatedStrs = ['simplifyz $2{,}9$'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'fr');
     });
 
     it('should translate math alone', function() {
@@ -503,7 +502,7 @@ describe('TranslationAssistant (math-translate)', function() {
         ];
         const translatedStrs = ['$3 \\cdot x = 9{,}9$', null];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'cs');
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
     });
 
     it('should translate multiple math notations at once', function() {
@@ -573,12 +572,10 @@ describe('TranslationAssistant (math-translate)', function() {
         assertSuggestions(allItems, itemsToTranslate, [
             'simplifyz $3 \\text{azul} = 2 \\mathbin{:} \\textbf{roja}$',
             'simplifyz $3 \\textbf{azul} = 2 \\mathbin{:} \\text{roja}$',
-        ], 'cs');
+        ]);
     });
 
-    // TODO(danielhollas): This we need to decide
     it('should not suggest ST if math is not translated properly', function() {
-        const lang = 'cs';
         const allItems = [{
             englishStr: 'simplify $2.3$',
             translatedStr: 'simplifyz $2.3$',
@@ -590,11 +587,10 @@ describe('TranslationAssistant (math-translate)', function() {
         const translatedStrs = [null];
         //const translatedStrs = ['simplifyz $2{,}9$'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
     });
 
     it('should not translate decimal point to comma for ko', function() {
-        const lang = 'ko';
         const allItems = [{
             englishStr: 'simplify $2.3$',
             translatedStr: 'simplifyz $2{,}3$',
@@ -605,11 +601,10 @@ describe('TranslationAssistant (math-translate)', function() {
         }];
         const translatedStrs = [null];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'ko');
     });
 
     it('should translate \\mult to \\cdot for cs locale', function() {
-        const lang = 'cs';
         const allItems = [{
             englishStr: 'simplify $2 \\mult 3 \\mult 2$',
             translatedStr: 'simplifyz $2 \\cdot 3 \\cdot 2$',
@@ -620,11 +615,10 @@ describe('TranslationAssistant (math-translate)', function() {
         }];
         const translatedStrs = ['simplifyz $2 \\cdot 9 \\cdot 9$'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
     });
 
     it('should translate \\div to \\mathbin{:} for de locale', function() {
-        const lang = 'de';
         const allItems = [{
             englishStr: 'simplify $2 \\div 3$',
             translatedStr: 'simplifyz $2 \\mathbin{:} 3$',
@@ -635,11 +629,10 @@ describe('TranslationAssistant (math-translate)', function() {
         }];
         const translatedStrs = ['simplifyz $2 \\mathbin{:} 9 \\mathbin{:} 3$'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'de');
     });
 
     it('should translate \\sin to \\sen for pt locale', function() {
-        const lang = 'pt';
         const allItems = [{
             englishStr: 'from $\\sin \\theta$ to $3\\sin$',
             translatedStr: 'fr $\\operatorname{sen} \\theta$ till ' +
@@ -651,7 +644,7 @@ describe('TranslationAssistant (math-translate)', function() {
         }];
         const translatedStrs = ['fr $\\operatorname{sen} \\theta$ till $5$'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'pt');
     });
 });
 
@@ -1124,7 +1117,7 @@ describe('TranslationAssistant (\\text{}, \\textbf{})', function() {
         }];
 
         const assistant = new TranslationAssistant(
-            allItems, getEnglishStr, getTranslation, lang);
+            allItems, getEnglishStr, getTranslation);
 
         const translation = assistant.suggest(itemsToTranslate);
         assert.equal(translation[0][1], null);


### PR DESCRIPTION
This PR adds a functionality for translations of certain math notations for different locales, as specified in this [google doc](https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0).

Only the most obvious cases from that doc are covered here: 
1. Decimal points to decimal commas
2. multiplication and division signs
3. latin version of sinus operator

Actually, the functionality was partially already in the repo, albeit not working. I fixed it, added the cases mentioned above and added some tests. Note that even this partial inelegant solution will be a BIG help for translators.

This PR partially solves #5 and is tracked in [JIRA ticket IC-116](https://khanacademy.atlassian.net/browse/IC-116).

Example: String 
`The answer is $5.6$`
need to be translated to Czech as 
`Výsledek je $5{,}6$`
But the previous version would detect the change in decimal point as a change in math code and would not offer Smart Translations.

**TODO before merge**
1. Ask the new advocates to fill in the google doc and update the code.
2. Think about the default behaviour when math notation in the translated string does not match our expectation. In the current version, I decided to be conservative and in the case of mismatch simply do not offer translations. For example, if the user forgets to translate the decimal point, we will not offer smart translations, which may potentially notify him that something is wrong. 