### PR TITLE
Auto-localize thousand separators.

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -136,8 +136,8 @@ mathDictionary) {
     outputs.forEach(function (output, outputIndex) {
 
         // NOTE(danielhollas): Currently, we will not offer smart translations
-        // if the user did not translate math according to our locale rules
-        // normalizeTranslatedMath only handles some special cases
+        // if the user did not translate math according to our locale rules,
+        // normalizeTranslatedMath only handles some special cases.
         if (findRegex === MATH_REGEX) {
             output = normalizeTranslatedMath(output, lang);
         }
@@ -355,6 +355,9 @@ function createTemplate(englishStr, translatedStr, lang) {
     }
 }
 
+// This array is used both in translateMath and normalizeTranslatedMath
+var THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu'];
+
 /**
  * Handles any per language special case translations
  * e.g. Portuguese uses `sen` instead of `sin`,
@@ -391,22 +394,25 @@ function translateMath(math, lang) {
     //{langs: ['bg'],
     //   regex: /\\times/g, replace: '\\mathbin\{.\}'},
 
-    // Thousand separator as a thin space
-    { langs: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu'],
-        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
+    // Thousand separator notations
+    // IMPORTANT NOTE(danielhollas):These must come before decimal comma!
 
     // No thousand separator
     { langs: ['ko'],
         regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1$2' },
 
     // Thousand separator as a dot
-    // NOTE(danielhollas): Extra braces around the dot are needed
-    // to distinguish this from decimal comma. It is vital to apply this
-    // regex before the regex for decimal comma!
+    // IMPORTANT NOTE(danielhollas): Extra braces around the dot are needed
+    // to distinguish this from decimal comma.
     { langs: ['pt', 'tr', 'da', 'sr', 'el', 'gr'],
         regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1{.}$2' },
 
+    // Thousand separator as a thin space
+    { langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
+        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
+
     // Decimal comma
+    // IMPORTANT NOTE(danielhollas): This should be tha LAST regex!
     { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
         regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' }];
 

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -378,7 +378,7 @@ function translateMath(math, lang) {
         regex: /\\div/g, replace: '\\mathbin\{:\}' },
 
     // latin trig functions
-    { langs: ['es', 'it', 'pt', 'pt-pt'],
+    { langs: ['it', 'pt', 'pt-pt'],
         regex: /\\sin/g, replace: '\\operatorname\{sen\}' },
 
     // multiplication sign as a centered dot

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -401,6 +401,11 @@ function translateMath(math, lang) {
     { langs: ['ko'],
         regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1$2' },
 
+    // Decimal comma
+    // IMPORTANT NOTE(danielhollas): This should be tha LAST regex!
+    { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
+        regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' },
+
     // Thousand separator as a dot
     // IMPORTANT NOTE(danielhollas): Extra braces around the dot are needed
     // to distinguish this from decimal comma.
@@ -409,12 +414,7 @@ function translateMath(math, lang) {
 
     // Thousand separator as a thin space
     { langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
-        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
-
-    // Decimal comma
-    // IMPORTANT NOTE(danielhollas): This should be tha LAST regex!
-    { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
-        regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' }];
+        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' }];
 
     mathTranslations.forEach(function (element) {
         if (element.langs.includes(lang)) {
@@ -445,7 +445,7 @@ function normalizeTranslatedMath(math, lang) {
     // braces are not really needed.
     // To understand why braces are needed around comma, see:
     // https://tex.stackexchange.com/questions/303110/avoid-space-after-thousands-separator-in-math-mode#303127
-    { langs: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it'],
+    { langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
         regex: /([0-9])\{\\,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' }];
 
     mathNormalizations.forEach(function (element) {
@@ -801,5 +801,8 @@ var TranslationAssistant = (function () {
 TranslationAssistant.stringToGroupKey = stringToGroupKey;
 TranslationAssistant.createTemplate = createTemplate;
 TranslationAssistant.populateTemplate = populateTemplate;
+TranslationAssistant.translateMath = translateMath;
+TranslationAssistant.normalizeTranslatedMath = normalizeTranslatedMath;
+TranslationAssistant.THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES;
 
 module.exports = TranslationAssistant;

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -137,9 +137,10 @@ mathDictionary) {
 
         // NOTE(danielhollas): Currently, we will not offer smart translations
         // if the user did not translate math according to our locale rules
-        // if (findRegex === MATH_REGEX) {
-        //     output = translateMath(output, lang);
-        // }
+        // normalizeTranslatedMath only handles some special cases
+        if (findRegex === MATH_REGEX) {
+            output = normalizeTranslatedMath(output, lang);
+        }
 
         var inputIndex = inputs.indexOf(output);
         if (inputIndex === -1) {
@@ -237,6 +238,7 @@ function getMathDictionary(englishStr, translatedStr, lang) {
     });
 
     outputs.forEach(function (output) {
+        output = normalizeTranslatedMath(output, lang);
         var normalized = output;
 
         replaceRegexes.forEach(function (_ref4) {
@@ -372,19 +374,75 @@ function translateMath(math, lang) {
 
     var mathTranslations = [
     // division sign as a colon
-    { langs: ['cs', 'de'],
-        regex: /\\div/g, replace: '\\mathbin{:}' },
+    { langs: ['cs', 'de', 'bg', 'hu'],
+        regex: /\\div/g, replace: '\\mathbin\{:\}' },
+
     // latin trig functions
     { langs: ['es', 'it', 'pt', 'pt-pt'],
         regex: /\\sin/g, replace: '\\operatorname\{sen\}' },
-    // Decimal comma
-    { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it'],
-        regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' },
+
     // multiplication sign as a centered dot
-    { langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu'],
-        regex: /\\times/g, replace: '\\cdot' }];
+    { langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv'],
+        regex: /\\times/g, replace: '\\cdot' },
+
+    // multiplication sign as a simple dot, a Bulgarian specialty
+    // TODO(danielhollas): not yet allowed by the linter
+    // TODO(danielhollas): add a test for this case
+    //{langs: ['bg'],
+    //   regex: /\\times/g, replace: '\\mathbin\{.\}'},
+
+    // Thousand separator as a thin space
+    { langs: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu'],
+        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
+
+    // No thousand separator
+    { langs: ['ko'],
+        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1$2' },
+
+    // Thousand separator as a dot
+    // NOTE(danielhollas): Extra braces around the dot are needed
+    // to distinguish this from decimal comma. It is vital to apply this
+    // regex before the regex for decimal comma!
+    { langs: ['pt', 'tr', 'da', 'sr', 'el', 'gr'],
+        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1{.}$2' },
+
+    // Decimal comma
+    { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
+        regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' }];
 
     mathTranslations.forEach(function (element) {
+        if (element.langs.includes(lang)) {
+            math = math.replace(element.regex, element.replace);
+        }
+    });
+
+    return math;
+}
+
+/**
+ * Perform regex substitutions on translated math strings
+ * so that it matches math translations that we do in translateMath()
+ *
+ * @param {string} math A user-translated math expression.
+ * @param {string} lang The locale of the translation language.
+ * @returns {string} The translated math expression.
+ */
+function normalizeTranslatedMath(math, lang) {
+
+    // NOTE(danielhollas): Maybe we could apply this regardless of locales
+    // to make the code more simple? Otherwise, the lists of locales here
+    // needs to be in sync with the list in translateMath function
+    var mathNormalizations = [
+    // Strip superfluous curly braces around \\,
+    // which is used as thousand separator in some locales
+    // i.e. 10{,}200 can be translated as 10{\\,}200, but the curly
+    // braces are not really needed.
+    // To understand why braces are needed around comma, see:
+    // https://tex.stackexchange.com/questions/303110/avoid-space-after-thousands-separator-in-math-mode#303127
+    { langs: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it'],
+        regex: /([0-9])\{\\,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' }];
+
+    mathNormalizations.forEach(function (element) {
         if (element.langs.includes(lang)) {
             math = math.replace(element.regex, element.replace);
         }

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -356,7 +356,7 @@ function createTemplate(englishStr, translatedStr, lang) {
 }
 
 // This array is used both in translateMath and normalizeTranslatedMath
-var THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu'];
+var THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu', 'uk'];
 
 /**
  * Handles any per language special case translations
@@ -377,7 +377,7 @@ function translateMath(math, lang) {
 
     var mathTranslations = [
     // division sign as a colon
-    { langs: ['cs', 'de', 'bg', 'hu'],
+    { langs: ['cs', 'de', 'bg', 'hu', 'uk'],
         regex: /\\div/g, replace: '\\mathbin\{:\}' },
 
     // latin trig functions

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -140,8 +140,8 @@ function getMapping(
     outputs.forEach((output, outputIndex) => {
 
         // NOTE(danielhollas): Currently, we will not offer smart translations
-        // if the user did not translate math according to our locale rules
-        // normalizeTranslatedMath only handles some special cases
+        // if the user did not translate math according to our locale rules,
+        // normalizeTranslatedMath only handles some special cases.
         if (findRegex === MATH_REGEX) {
             output = normalizeTranslatedMath(output, lang);
         }
@@ -358,6 +358,10 @@ function createTemplate(englishStr, translatedStr, lang) {
     }
 }
 
+// This array is used both in translateMath and normalizeTranslatedMath
+const THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de',
+      'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu'];
+
 /**
  * Handles any per language special case translations
  * e.g. Portuguese uses `sen` instead of `sin`,
@@ -394,23 +398,25 @@ function translateMath(math, lang) {
          //{langs: ['bg'],
          //   regex: /\\times/g, replace: '\\mathbin\{.\}'},
 
-         // Thousand separator as a thin space
-         {langs: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl',
-                  'az', 'se', 'it', 'hu'],
-            regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2'},
+         // Thousand separator notations
+         // IMPORTANT NOTE(danielhollas):These must come before decimal comma!
 
          // No thousand separator
          {langs: ['ko'],
             regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1$2'},
 
          // Thousand separator as a dot
-         // NOTE(danielhollas): Extra braces around the dot are needed
-         // to distinguish this from decimal comma. It is vital to apply this
-         // regex before the regex for decimal comma!
+         // IMPORTANT NOTE(danielhollas): Extra braces around the dot are needed
+         // to distinguish this from decimal comma.
          {langs: ['pt', 'tr', 'da', 'sr', 'el', 'gr'],
             regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1{.}$2'},
 
+         // Thousand separator as a thin space
+         {langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
+            regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2'},
+
          // Decimal comma
+         // IMPORTANT NOTE(danielhollas): This should be tha LAST regex!
          {langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro',
            'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
             regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2'},

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -451,8 +451,7 @@ function normalizeTranslatedMath(math, lang) {
          // braces are not really needed.
          // To understand why braces are needed around comma, see:
          // https://tex.stackexchange.com/questions/303110/avoid-space-after-thousands-separator-in-math-mode#303127
-         {langs: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl',
-                  'az', 'se', 'it'],
+         {langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
             regex: /([0-9])\{\\,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2'},
     ];
 
@@ -773,5 +772,9 @@ class TranslationAssistant {
 TranslationAssistant.stringToGroupKey = stringToGroupKey;
 TranslationAssistant.createTemplate = createTemplate;
 TranslationAssistant.populateTemplate = populateTemplate;
+TranslationAssistant.translateMath = translateMath;
+TranslationAssistant.normalizeTranslatedMath = normalizeTranslatedMath;
+TranslationAssistant.THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES =
+THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES;
 
 module.exports = TranslationAssistant;

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -381,7 +381,7 @@ function translateMath(math, lang) {
             regex: /\\div/g, replace: '\\mathbin\{:\}'},
 
          // latin trig functions
-         {langs: ['es', 'it', 'pt', 'pt-pt'],
+         {langs: ['it', 'pt', 'pt-pt'],
             regex: /\\sin/g, replace: '\\operatorname\{sen\}'},
 
          // multiplication sign as a centered dot

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -360,7 +360,7 @@ function createTemplate(englishStr, translatedStr, lang) {
 
 // This array is used both in translateMath and normalizeTranslatedMath
 const THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de',
-      'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu'];
+      'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu', 'uk'];
 
 /**
  * Handles any per language special case translations
@@ -381,7 +381,7 @@ function translateMath(math, lang) {
 
     const mathTranslations = [
          // division sign as a colon
-         {langs: ['cs', 'de', 'bg', 'hu'],
+         {langs: ['cs', 'de', 'bg', 'hu', 'uk'],
             regex: /\\div/g, replace: '\\mathbin\{:\}'},
 
          // latin trig functions

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -141,9 +141,10 @@ function getMapping(
 
         // NOTE(danielhollas): Currently, we will not offer smart translations
         // if the user did not translate math according to our locale rules
-        // if (findRegex === MATH_REGEX) {
-        //     output = translateMath(output, lang);
-        // }
+        // normalizeTranslatedMath only handles some special cases
+        if (findRegex === MATH_REGEX) {
+            output = normalizeTranslatedMath(output, lang);
+        }
 
         const inputIndex = inputs.indexOf(output);
         if (inputIndex === -1) {
@@ -241,6 +242,7 @@ function getMathDictionary(englishStr, translatedStr, lang) {
     });
 
     outputs.forEach((output) => {
+        output = normalizeTranslatedMath(output, lang);
         let normalized = output;
 
         replaceRegexes.forEach(([regex, str]) => {
@@ -375,21 +377,80 @@ function translateMath(math, lang) {
 
     const mathTranslations = [
          // division sign as a colon
-         {langs: ['cs', 'de'],
-            regex: /\\div/g, replace: '\\mathbin{:}'},
+         {langs: ['cs', 'de', 'bg', 'hu'],
+            regex: /\\div/g, replace: '\\mathbin\{:\}'},
+
          // latin trig functions
          {langs: ['es', 'it', 'pt', 'pt-pt'],
             regex: /\\sin/g, replace: '\\operatorname\{sen\}'},
+
+         // multiplication sign as a centered dot
+         {langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv'],
+            regex: /\\times/g, replace: '\\cdot'},
+
+         // multiplication sign as a simple dot, a Bulgarian specialty
+         // TODO(danielhollas): not yet allowed by the linter
+         // TODO(danielhollas): add a test for this case
+         //{langs: ['bg'],
+         //   regex: /\\times/g, replace: '\\mathbin\{.\}'},
+
+         // Thousand separator as a thin space
+         {langs: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl',
+                  'az', 'se', 'it', 'hu'],
+            regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2'},
+
+         // No thousand separator
+         {langs: ['ko'],
+            regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1$2'},
+
+         // Thousand separator as a dot
+         // NOTE(danielhollas): Extra braces around the dot are needed
+         // to distinguish this from decimal comma. It is vital to apply this
+         // regex before the regex for decimal comma!
+         {langs: ['pt', 'tr', 'da', 'sr', 'el', 'gr'],
+            regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1{.}$2'},
+
          // Decimal comma
          {langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro',
-           'nl', 'hu', 'az', 'it'],
+           'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
             regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2'},
-         // multiplication sign as a centered dot
-         {langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu'],
-            regex: /\\times/g, replace: '\\cdot'},
     ];
 
     mathTranslations.forEach(function(element) {
+        if (element.langs.includes(lang)) {
+            math = math.replace(element.regex, element.replace);
+        }
+    });
+
+    return math;
+}
+
+/**
+ * Perform regex substitutions on translated math strings
+ * so that it matches math translations that we do in translateMath()
+ *
+ * @param {string} math A user-translated math expression.
+ * @param {string} lang The locale of the translation language.
+ * @returns {string} The translated math expression.
+ */
+function normalizeTranslatedMath(math, lang) {
+
+    // NOTE(danielhollas): Maybe we could apply this regardless of locales
+    // to make the code more simple? Otherwise, the lists of locales here
+    // needs to be in sync with the list in translateMath function
+    const mathNormalizations = [
+         // Strip superfluous curly braces around \\,
+         // which is used as thousand separator in some locales
+         // i.e. 10{,}200 can be translated as 10{\\,}200, but the curly
+         // braces are not really needed.
+         // To understand why braces are needed around comma, see:
+         // https://tex.stackexchange.com/questions/303110/avoid-space-after-thousands-separator-in-math-mode#303127
+         {langs: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl',
+                  'az', 'se', 'it'],
+            regex: /([0-9])\{\\,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2'},
+    ];
+
+    mathNormalizations.forEach(function(element) {
         if (element.langs.includes(lang)) {
             math = math.replace(element.regex, element.replace);
         }

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -529,6 +529,18 @@ describe('TranslationAssistant (math-translate)', function() {
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'de');
     });
 
+    //NOTE(danielhollas): In reality, TA should only get unescaped strings
+    //from Manticore. But I guess this test does not hurt either.
+    it('should handle doubly-escaped latex commands', function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3 \\\\times x = 9.9 \\\\div 3$', translatedStr: ''},
+        ];
+        const translatedStrs = ['$3 \\\\cdot x = 9{,}9 \\\\mathbin{:} 3$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+    });
+
     it('should translate multiple decimals', function() {
         const allItems = [];
         const itemsToTranslate = [
@@ -537,6 +549,96 @@ describe('TranslationAssistant (math-translate)', function() {
         const translatedStrs = ['$3 \\cdot x = 9{,}9 \\mathbin{:} 3{,}3$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'de');
+    });
+
+    it('should translate thousand separator for a thin space', function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000 $',
+             translatedStr: ''},
+        ];
+        const translatedStrs =
+           ['$3\\,000{,}5 \\cdot x = 9{,}9 \\mathbin{:} 3\\,300\\,000 $'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+    });
+
+    it('should not translate thousand separator for ja locale', function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000$',
+             translatedStr: ''},
+        ];
+        const translatedStrs =
+           ['$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'ja');
+    });
+
+    it('should handle extra braces around thousand separator', function() {
+        const allItems = [{
+            englishStr: 'simplify $2{,}300 20{,}000{,}090$',
+            translatedStr: 'simplifyz $2{\\,}300 20{\\,}000{\\,}090$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $2{,}000{,}000$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['simplifyz $2\\,000\\,000$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+    });
+
+    it('should handle superfluous braces together with \\text', function() {
+        const allItems = [{
+            englishStr: 'simplify $2{,}300 \\text{to} 20{,}000{,}090$',
+            translatedStr: 'simplifyz $2{\\,}300 \\text{t} 20{\\,}000{\\,}090$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $2{,}000{,}000 \\text{to} 20{,}857$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['simplifyz $2\\,000\\,000 \\text{t} 20\\,857$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+    });
+
+    it('should handle superfluous braces together with \\textbf', function() {
+        const allItems = [{
+            englishStr: 'simplify $2{,}300 \\textbf{to} 2{,}000{,}090$',
+            translatedStr: 'simplif $2{\\,}300 \\textbf{t} 2{\\,}000{\\,}090$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $2{,}000{,}000 \\textbf{to} 20{,}857$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['simplif $2\\,000\\,000 \\textbf{t} 20\\,857$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+    });
+
+    it('should translate thousand separator to none for ko locale', function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000$',
+             translatedStr: ''},
+        ];
+        const translatedStrs =
+           ['$3000.5 \\times x = 9.9 \\div 3300000$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'ko');
+    });
+
+    it('should translate thousand separator to . for pt locale', function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000 $',
+             translatedStr: ''},
+        ];
+        const translatedStrs =
+           ['$3{.}000{,}5 \\times x = 9{,}9 \\div 3{.}300{.}000 $'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'pt');
     });
 
     it('should translate math with \\text', function() {

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -529,8 +529,8 @@ describe('TranslationAssistant (math-translate)', function() {
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'de');
     });
 
-    //NOTE(danielhollas): In reality, TA should only get unescaped strings
-    //from Manticore. But I guess this test does not hurt either.
+    // NOTE(danielhollas): In reality, TA should only get unescaped strings
+    // from Manticore. But I guess this test does not hurt either.
     it('should handle doubly-escaped latex commands', function() {
         const allItems = [];
         const itemsToTranslate = [
@@ -559,6 +559,19 @@ describe('TranslationAssistant (math-translate)', function() {
         ];
         const translatedStrs =
            ['$3\\,000{,}5 \\cdot x = 9{,}9 \\mathbin{:} 3\\,300\\,000 $'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+    });
+
+    it('should handle both thousand sep. AND decimal comma for cs locale',
+    function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3{,}000.500 \\times x = 9.900 \\div 3{,}300{,}000 $',
+             translatedStr: ''},
+        ];
+        const translatedStrs =
+           ['$3\\,000{,}500 \\cdot x = 9{,}900 \\mathbin{:} 3\\,300\\,000 $'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs);
     });
@@ -620,11 +633,11 @@ describe('TranslationAssistant (math-translate)', function() {
     it('should translate thousand separator to none for ko locale', function() {
         const allItems = [];
         const itemsToTranslate = [
-            {englishStr: '$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000$',
+            {englishStr: '$3{,}000.500 \\times x = 9.900 \\div 3{,}300{,}000$',
              translatedStr: ''},
         ];
         const translatedStrs =
-           ['$3000.5 \\times x = 9.9 \\div 3300000$'];
+           ['$3000.500 \\times x = 9.900 \\div 3300000$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'ko');
     });
@@ -637,6 +650,19 @@ describe('TranslationAssistant (math-translate)', function() {
         ];
         const translatedStrs =
            ['$3{.}000{,}5 \\times x = 9{,}9 \\div 3{.}300{.}000 $'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'pt');
+    });
+
+    it('should handle thousand separator AND decimal comma for pt locale',
+    function() {
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$3{,}000.540 \\times x = 9.900 \\div 3{,}300{,}000 $',
+             translatedStr: ''},
+        ];
+        const translatedStrs =
+           ['$3{.}000{,}540 \\times x = 9{,}900 \\div 3{.}300{.}000 $'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'pt');
     });


### PR DESCRIPTION
   Add capability to translate US thousand separators by Smart Translations.
   This builds on the functionality introduced in previous commits.
   I also updated locale lists for other math notations.

See comment below. 
~~~There is one unsolved tricky thing: Some languages use _thin space_ as a decimal separator. The correct LaTex command is `\,`, but depending on how Crowdin processed a particular string, it also sometimes needs to be `\\,`. See discussion linked below about why that is. At this moment, TA has no way of knowing whether to use single or double backslash for a particular string. AFAIK manticore uses some kind of heuristic to determine this. Some explanation about the heuristics is given in [this JIRA ticker](https://khanacademy.atlassian.net/browse/IC-111)~~~

~~~I see several possibilities how to handle this:~~~

~~~1. Recreate the heuristic in TM.~~~
~~~2. Pass the information whether to use single or double backslash from manticore to TM as a parameter.~~~
~~~3. Infer the solution from a user-translated template a pray that the user got it right.~~~

~~~1.and 3. are clearly suboptimal, but I dunno how difficult 2 would be. Note the within a string pattern, different strings can differ in the convention. So if manticore passes all untranslated strings to TA at once, approach 2 would not work.~~~

Auxiliary [JIRA ticket](https://khanacademy.atlassian.net/browse/IC-226)
[Discussion on Discourse](https://international-forum.khanacademy.org/t/correct-notation-for-thousand-separators/543/24)

@mpolyak would you mind taking this? There is no rush, but I wanted to get the ball rolling on this one and need further input from someone. 
Thanks!