### PR TITLE
Fix the build.

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -356,7 +356,7 @@ function createTemplate(englishStr, translatedStr, lang) {
 }
 
 // This array is used both in translateMath and normalizeTranslatedMath
-var THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu', 'uk'];
+var THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'];
 
 /**
  * Handles any per language special case translations
@@ -377,22 +377,22 @@ function translateMath(math, lang) {
 
     var mathTranslations = [
     // division sign as a colon
-    { langs: ['cs', 'de', 'bg', 'hu', 'uk'],
-        regex: /\\div/g, replace: '\\mathbin\{:\}' },
+    { langs: ['cs', 'de', 'bg', 'hu', 'uk', 'da'],
+        regex: /\\div/g, replace: '\\mathbin{:}' },
 
     // latin trig functions
     { langs: ['it', 'pt', 'pt-pt'],
-        regex: /\\sin/g, replace: '\\operatorname\{sen\}' },
+        regex: /\\sin/g, replace: '\\operatorname{sen}' },
 
     // multiplication sign as a centered dot
-    { langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv'],
+    { langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da'],
         regex: /\\times/g, replace: '\\cdot' },
 
     // multiplication sign as a simple dot, a Bulgarian specialty
     // TODO(danielhollas): not yet allowed by the linter
     // TODO(danielhollas): add a test for this case
     //{langs: ['bg'],
-    //   regex: /\\times/g, replace: '\\mathbin\{.\}'},
+    //   regex: /\\times/g, replace: '\\mathbin{.}'},
 
     // Thousand separator notations
     // IMPORTANT NOTE(danielhollas):These must come before decimal comma!
@@ -400,11 +400,6 @@ function translateMath(math, lang) {
     // No thousand separator
     { langs: ['ko'],
         regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1$2' },
-
-    // Decimal comma
-    // IMPORTANT NOTE(danielhollas): This should be tha LAST regex!
-    { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
-        regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' },
 
     // Thousand separator as a dot
     // IMPORTANT NOTE(danielhollas): Extra braces around the dot are needed
@@ -414,7 +409,12 @@ function translateMath(math, lang) {
 
     // Thousand separator as a thin space
     { langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
-        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' }];
+        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
+
+    // Decimal comma
+    // IMPORTANT NOTE(danielhollas): This should be tha LAST regex!
+    { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
+        regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' }];
 
     mathTranslations.forEach(function (element) {
         if (element.langs.includes(lang)) {

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -360,7 +360,7 @@ function createTemplate(englishStr, translatedStr, lang) {
 
 // This array is used both in translateMath and normalizeTranslatedMath
 const THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de',
-      'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'se', 'it', 'hu', 'uk'];
+      'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'];
 
 /**
  * Handles any per language special case translations
@@ -381,22 +381,22 @@ function translateMath(math, lang) {
 
     const mathTranslations = [
          // division sign as a colon
-         {langs: ['cs', 'de', 'bg', 'hu', 'uk'],
-            regex: /\\div/g, replace: '\\mathbin\{:\}'},
+         {langs: ['cs', 'de', 'bg', 'hu', 'uk', 'da'],
+            regex: /\\div/g, replace: '\\mathbin{:}'},
 
          // latin trig functions
          {langs: ['it', 'pt', 'pt-pt'],
-            regex: /\\sin/g, replace: '\\operatorname\{sen\}'},
+            regex: /\\sin/g, replace: '\\operatorname{sen}'},
 
          // multiplication sign as a centered dot
-         {langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv'],
+         {langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da'],
             regex: /\\times/g, replace: '\\cdot'},
 
          // multiplication sign as a simple dot, a Bulgarian specialty
          // TODO(danielhollas): not yet allowed by the linter
          // TODO(danielhollas): add a test for this case
          //{langs: ['bg'],
-         //   regex: /\\times/g, replace: '\\mathbin\{.\}'},
+         //   regex: /\\times/g, replace: '\\mathbin{.}'},
 
          // Thousand separator notations
          // IMPORTANT NOTE(danielhollas):These must come before decimal comma!


### PR DESCRIPTION
I forgot to rebuild in the last commit. There are currently 3 failing tests on master if you do not run
 `npm run build` before running the tests. As a result, STs are now incorrect for a number of locales if 
a string contains both thousand separators and decimals.

I am assuming here that the code is not being automatically rebuild in Translation Editor. I did not actually test the behavior in the Translation Editor.

@mpolyak will you be able to take a look? This seems as pretty important, I am very sorry about this.

In a future PR, I am gonna make a handling of thousand separators more robust.
I will also start using the "watch build" feature to prevent this in the future.