### PR TITLE
Better handling of thousand separators

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -356,6 +356,23 @@ function createTemplate(englishStr, translatedStr, lang) {
 }
 
 /**
+ * Locale lists for different math notations, taken from this table:
+ * https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0
+ * TODO(danielhollas): Need to update this when new langs join translations
+ */
+var MATH_RULES_LOCALES = {
+    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
+    THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el'],
+    NO_THOUSAND_SEP: ['ko', 'ps'],
+    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el'],
+    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da'],
+    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da'],
+    SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
+    ARABIC_COMMA: ['ps'],
+    PERSO_ARABIC_NUMERALS: ['ps']
+};
+
+/**
  * Translates western-arabic numerals to others, see:
  * https://en.wikipedia.org/wiki/Eastern_Arabic_numerals
  *
@@ -367,8 +384,7 @@ function translateNumerals(math, lang) {
     // Perso-Arabic numerals (Used by Pashto)
     // TODO(danielhollas): Move this const to a better place,
     // pending PR #13
-    var PERSO_ARABIC_NUMERALS_LOCALES = ['ps'];
-    if (PERSO_ARABIC_NUMERALS_LOCALES.includes(lang)) {
+    if (MATH_RULES_LOCALES.PERSO_ARABIC_NUMERALS.includes(lang)) {
         math = math.replace(/1/g, '۱').replace(/2/g, '۲').replace(/3/g, '۳').replace(/4/g, '۴').replace(/5/g, '۵').replace(/6/g, '۶').replace(/7/g, '۷').replace(/8/g, '۸').replace(/9/g, '۹').replace(/0/g, '۰');
     }
     // TODO(danielhollas): Implement Eastern-Arabic numerals
@@ -379,19 +395,9 @@ function translateNumerals(math, lang) {
     return math;
 }
 
-// This array is used both in translateMath and normalizeTranslatedMath
-var THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'];
-
 /**
  * Handles any per language special case translations
- * e.g. Portuguese uses `sen` instead of `sin`,
- * many languages use decimal comma etc.
- *
- * The list of all per-locale math notations is in this table:
- * https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0
- *
- * TODO(danielhollas): For now only the obvious cases were implemented.
- * TODO(danielhollas): Need to update this when new langs join translations
+ * e.g. thousand separators, decimal commas etc.
  *
  * @param {string} math A math expression to translate for locale.
  * @param {string} lang The locale of the translation language.
@@ -399,17 +405,39 @@ var THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de', 'pt-pt', 'nb',
  */
 function translateMath(math, lang) {
 
+    // These consts are used only here for manimupulating thousand separator
+    var placeholder = 'THSEP';
+    var USThousandSeparatorRegex = new RegExp('([0-9])' + placeholder + '([0-9])(?=[0-9]{2})', 'g');
+    var thousandSeparatorLocales = MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.concat(MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT, MATH_RULES_LOCALES.NO_THOUSAND_SEP);
+
     var mathTranslations = [
+    // IMPORTANT NOTE: This MUST be the first regex
+    // Convert thousand separators to a placeholder
+    // to prevent interactions with decimal commas
+    { langs: thousandSeparatorLocales,
+        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g,
+        replace: '$1' + placeholder + '$2' },
+
+    // Decimal comma
+    { langs: MATH_RULES_LOCALES.DECIMAL_COMMA,
+        regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' },
+
+    // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
+    // NOTE: At least in MathJax, this comma does not need braces,
+    // but it feels safer to have them here.
+    { langs: MATH_RULES_LOCALES.ARABIC_COMMA,
+        regex: /([0-9])\.([0-9])/g, replace: '$1{،}$2' },
+
     // division sign as a colon
-    { langs: ['cs', 'de', 'bg', 'hu', 'uk', 'da'],
+    { langs: MATH_RULES_LOCALES.DIV_AS_COLON,
         regex: /\\div/g, replace: '\\mathbin{:}' },
 
     // latin trig functions
-    { langs: ['it', 'pt', 'pt-pt'],
+    { langs: MATH_RULES_LOCALES.SIN_AS_SEN,
         regex: /\\sin/g, replace: '\\operatorname{sen}' },
 
     // multiplication sign as a centered dot
-    { langs: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da'],
+    { langs: MATH_RULES_LOCALES.TIMES_AS_CDOT,
         regex: /\\times/g, replace: '\\cdot' },
 
     // multiplication sign as a simple dot, a Bulgarian specialty
@@ -419,32 +447,18 @@ function translateMath(math, lang) {
     //   regex: /\\times/g, replace: '\\mathbin{.}'},
 
     // Thousand separator notations
-    // IMPORTANT NOTE(danielhollas):These must come before decimal comma!
 
     // No thousand separator
-    { langs: ['ko', 'ps'],
-        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1$2' },
+    { langs: MATH_RULES_LOCALES.NO_THOUSAND_SEP,
+        regex: USThousandSeparatorRegex, replace: '$1$2' },
 
     // Thousand separator as a dot
-    // IMPORTANT NOTE(danielhollas): Extra braces around the dot are needed
-    // to distinguish this from decimal comma.
-    { langs: ['pt', 'tr', 'da', 'sr', 'el', 'gr'],
-        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1{.}$2' },
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
+        regex: USThousandSeparatorRegex, replace: '$1.$2' },
 
-    // Thousand separator as a thin space
-    { langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
-        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
-
-    // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
-    // NOTE: At least in MathJax, this comma does not need braces,
-    // but it feels safer to have them here.
-    { langs: ['ps'],
-        regex: /([0-9])\.([0-9])/g, replace: '$1{،}$2' },
-
-    // Decimal comma
-    // IMPORTANT NOTE(danielhollas): This should be tha LAST regex!
-    { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
-        regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' }];
+    // Thousand separator as a thin space (\, in Tex)
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        regex: USThousandSeparatorRegex, replace: '$1\\,$2' }];
 
     mathTranslations.forEach(function (element) {
         if (element.langs.includes(lang)) {
@@ -466,9 +480,6 @@ function translateMath(math, lang) {
  */
 function normalizeTranslatedMath(math, lang) {
 
-    // NOTE(danielhollas): Maybe we could apply this regardless of locales
-    // to make the code more simple? Otherwise, the lists of locales here
-    // needs to be in sync with the list in translateMath function
     var mathNormalizations = [
     // Strip superfluous curly braces around \\,
     // which is used as thousand separator in some locales
@@ -476,8 +487,18 @@ function normalizeTranslatedMath(math, lang) {
     // braces are not really needed.
     // To understand why braces are needed around comma, see:
     // https://tex.stackexchange.com/questions/303110/avoid-space-after-thousands-separator-in-math-mode#303127
-    { langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
-        regex: /([0-9])\{\\,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' }];
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        regex: /([0-9])\{\\,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
+
+    // Strip extra braces around a dot as a thousand separator
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
+        regex: /([0-9])\{\.\}([0-9])(?=[0-9]{2})/g, replace: '$1.$2' },
+
+    // Allow translators to use a full space (~ in LaTeX)
+    // (but TA will always suggest thin space \,)
+    // We cannot allow a literal space here, cause Tex would ignore it
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        regex: /([0-9])\{?~\}?([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' }];
 
     mathNormalizations.forEach(function (element) {
         if (element.langs.includes(lang)) {
@@ -834,6 +855,6 @@ TranslationAssistant.createTemplate = createTemplate;
 TranslationAssistant.populateTemplate = populateTemplate;
 TranslationAssistant.translateMath = translateMath;
 TranslationAssistant.normalizeTranslatedMath = normalizeTranslatedMath;
-TranslationAssistant.THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES;
+TranslationAssistant.MATH_RULES_LOCALES = MATH_RULES_LOCALES;
 
 module.exports = TranslationAssistant;

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -9,7 +9,7 @@ const {
     populateTemplate,
     translateMath,
     normalizeTranslatedMath,
-    THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
+    MATH_RULES_LOCALES,
 } = TranslationAssistant;
 
 /**
@@ -489,21 +489,48 @@ describe('translateMath', function() {
         assert.equal(outputStr, englishStr);
     });
 
-    it('should translate thousand separator for THOUSAND_SEPARATOR_... locales',
-    function() {
+    it('should translate thousand separator as thin space', function() {
         const englishStr = '1{,}000{,}000 + 9{,}000';
         const translatedStr = '1\\,000\\,000 + 9\\,000';
 
-        THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES.forEach(function(locale) {
+        MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.forEach(function(locale) {
             const outputStr = translateMath(englishStr, locale);
             assert.equal(outputStr, translatedStr);
         });
+    });
+
+    it('should translate thousand separator as a dot', function() {
+        const englishStr = '1{,}000{,}000 + 9{,}000';
+        const translatedStr = '1.000.000 + 9.000';
+
+        MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT.forEach(function(locale) {
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
+    });
+
+    it('should translate thousand separator for none', function() {
+        const englishStr = '1{,}000{,}000 + 9{,}000';
+        const translatedStr = '1000000 + 9000';
+
+        const outputStr = translateMath(englishStr, 'ko');
+        assert.equal(outputStr, translatedStr);
     });
 
     it('should not translate thousand separator for en locale', function() {
         const englishStr = '1{,}000{,}000 + 9{,}000';
         const outputStr = translateMath(englishStr, 'en');
         assert.equal(outputStr, englishStr);
+    });
+
+    it('should translate decimal point to decimal comma', function() {
+        const englishStr = '1000.000 + 9.4 + 45.0';
+        const translatedStr = '1000{,}000 + 9{,}4 + 45{,}0';
+
+        MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
     });
 
     it('should translate both thousand sep. and decimal point for cs locale',
@@ -514,28 +541,48 @@ describe('translateMath', function() {
         assert.equal(outputStr, translatedStr);
     });
 
-    it('should translate notation for multiplication and division',
-    function() {
-        const englishStr = '2 \\times 2 = 8 \\div 2';
-        const translatedStr = '2 \\cdot 2 = 8 \\mathbin{:} 2';
+    it('should translate notation for multiplication', function() {
+        MATH_RULES_LOCALES.TIMES_AS_CDOT.forEach(function(locale) {
+            const englishStr = '2 \\times 2 = 4';
+            const translatedStr = '2 \\cdot 2 = 4';
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
+    });
+
+    it('should translate notation for division', function() {
+        MATH_RULES_LOCALES.DIV_AS_COLON.forEach(function(locale) {
+            const englishStr = '8 \\div 2 = 4';
+            const translatedStr = '8 \\mathbin{:} 2 = 4';
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
+    });
+
+    it('should translate different math notations simultaneously', function() {
+        const englishStr = '8\\div 2=2 \\times 2, 1{,}000{,}000.874';
+        const translatedStr = '8\\mathbin{:} 2=2 \\cdot 2, 1\\,000\\,000{,}874';
         const outputStr = translateMath(englishStr, 'cs');
         assert.equal(outputStr, translatedStr);
     });
 
     it('should translate notation for sinus for certain locales',
     function() {
-        const englishStr = '\\sin \\theta';
-        const translatedStr = '\\operatorname{sen} \\theta';
-        const outputStr = translateMath(englishStr, 'pt');
-        assert.equal(outputStr, translatedStr);
+        MATH_RULES_LOCALES.SIN_AS_SEN.forEach(function(locale) {
+            const englishStr = '\\sin \\theta';
+            const translatedStr = '\\operatorname{sen} \\theta';
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
     });
 
-    it('should translate western- to eastern-arabic numerals for pashto',
-    function() {
-        const englishStr = '1234567890';
-        const translatedStr = '۱۲۳۴۵۶۷۸۹۰';
-        const outputStr = translateMath(englishStr, 'ps');
-        assert.equal(outputStr, translatedStr);
+    it('should translate western- to perso-arabic numerals', function() {
+        MATH_RULES_LOCALES.PERSO_ARABIC_NUMERALS.forEach(function(locale) {
+            const englishStr = '1234567890';
+            const translatedStr = '۱۲۳۴۵۶۷۸۹۰';
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
     });
 
     it('should use arabic decimal comma and no thousand separator for pashto',
@@ -553,7 +600,18 @@ describe('normalizeTranslatedMath', function() {
         const translatedStr = '1{\\,}000{\\,}000 + 9\\,000';
         const normalizedStr = '1\\,000\\,000 + 9\\,000';
 
-        THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES.forEach(function(locale) {
+        MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.forEach(function(locale) {
+            const outputStr = normalizeTranslatedMath(translatedStr, locale);
+            assert.equal(outputStr, normalizedStr);
+        });
+    });
+
+    it('should strip extra braces around thousand separator as a dot',
+    function() {
+        const translatedStr = '1{.}000{.}000 + 9.000 + 1{,}2';
+        const normalizedStr = '1.000.000 + 9.000 + 1{,}2';
+
+        MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT.forEach(function(locale) {
             const outputStr = normalizeTranslatedMath(translatedStr, locale);
             assert.equal(outputStr, normalizedStr);
         });
@@ -563,6 +621,34 @@ describe('normalizeTranslatedMath', function() {
     function() {
         const translatedStr = '1{\\,}000{\\,}000 + 9\\,000';
         const normalizedStr = '1{\\,}000{\\,}000 + 9\\,000';
+        const outputStr = normalizeTranslatedMath(translatedStr, 'en');
+        assert.equal(outputStr, normalizedStr);
+    });
+
+    it('should convert ~ to thin space as thousand separator', function() {
+        const translatedStr = '1~000~000 + 9~000';
+        const normalizedStr = '1\\,000\\,000 + 9\\,000';
+
+        MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.forEach(
+        function(locale) {
+            const outputStr = normalizeTranslatedMath(translatedStr, locale);
+            assert.equal(outputStr, normalizedStr);
+        });
+    });
+
+    it('should convert {~} to thin space as thousand separator', function() {
+        const translatedStr = '1{~}000{~}000 + 9{~}000';
+        const normalizedStr = '1\\,000\\,000 + 9\\,000';
+
+        MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.forEach(function(locale) {
+            const outputStr = normalizeTranslatedMath(translatedStr, locale);
+            assert.equal(outputStr, normalizedStr);
+        });
+    });
+
+    it('should NOT convert ~ to thin space for en locale', function() {
+        const translatedStr = '1~000~000 + 9~000';
+        const normalizedStr = '1~000~000 + 9~000';
         const outputStr = normalizeTranslatedMath(translatedStr, 'en');
         assert.equal(outputStr, normalizedStr);
     });
@@ -692,6 +778,20 @@ describe('TranslationAssistant (math-translate)', function() {
         assertSuggestions(allItems, itemsToTranslate, translatedStrs);
     });
 
+    it('should allow ~ as a thousand separator', function() {
+        const allItems = [{
+            englishStr: 'simplify $2{,}300 20{,}000{,}090$',
+            translatedStr: 'simplifyz $2~300 20~000~090$',
+        }];
+        const itemsToTranslate = [{
+            englishStr: 'simplify $2{,}000{,}000$',
+            translatedStr: '',
+        }];
+        const translatedStrs = ['simplifyz $2\\,000\\,000$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+    });
+
     it('should handle superfluous braces together with \\text', function() {
         const allItems = [{
             englishStr: 'simplify $2{,}300 \\text{to} 20{,}000{,}090$',
@@ -739,7 +839,7 @@ describe('TranslationAssistant (math-translate)', function() {
              translatedStr: ''},
         ];
         const translatedStrs =
-           ['$3{.}000{,}5 \\times x = 9{,}9 \\div 3{.}300{.}000 $'];
+           ['$3.000{,}5 \\times x = 9{,}9 \\div 3.300.000 $'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'pt');
     });
@@ -752,7 +852,7 @@ describe('TranslationAssistant (math-translate)', function() {
              translatedStr: ''},
         ];
         const translatedStrs =
-           ['$3{.}000{,}540 \\times x = 9{,}900 \\div 3{.}300{.}000 $'];
+           ['$3.000{,}540 \\times x = 9{,}900 \\div 3.300.000 $'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'pt');
     });


### PR DESCRIPTION
This PR has two goals:

1. Safer handling of thousand separator regex
2. More rules for normalizeMathTranslations so that we are less strict about the thousand separators.

Ad. 1. 
_Strategy_: 
As a very first regex, replace thousand separators with placeholders, to reduce risk of mingling with decimal commas. This will also allow us to better handle languages which have decimal commas and a dot for thousand separator (i.e. reversed EN notation).
_Challenge_: 
For the first regex, we will need to combine locale lists for all different notations. This means creating more consts like `THOUSAND_SEPARATOR_AS_THIN_SPACE`. At this point, it might be better to encapsulate them in an object.