### PR TITLE
Add support for Arabic decimal comma and numerals

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -355,6 +355,30 @@ function createTemplate(englishStr, translatedStr, lang) {
     }
 }
 
+/**
+ * Translates western-arabic numerals to others, see:
+ * https://en.wikipedia.org/wiki/Eastern_Arabic_numerals
+ *
+ * @param {string} math A math expression to translate for locale.
+ * @param {string} lang The locale of the translation language.
+ * @returns {string} The math expression with translated numerals.
+ */
+function translateNumerals(math, lang) {
+    // Perso-Arabic numerals (Used by Pashto)
+    // TODO(danielhollas): Move this const to a better place,
+    // pending PR #13
+    var PERSO_ARABIC_NUMERALS_LOCALES = ['ps'];
+    if (PERSO_ARABIC_NUMERALS_LOCALES.includes(lang)) {
+        math = math.replace(/1/g, '۱').replace(/2/g, '۲').replace(/3/g, '۳').replace(/4/g, '۴').replace(/5/g, '۵').replace(/6/g, '۶').replace(/7/g, '۷').replace(/8/g, '۸').replace(/9/g, '۹').replace(/0/g, '۰');
+    }
+    // TODO(danielhollas): Implement Eastern-Arabic numerals
+    // (currently not in use by any team)
+    // Unicode code-points for these are different from the Perso-Arabic,
+    // even though some of the numbers look the same!
+
+    return math;
+}
+
 // This array is used both in translateMath and normalizeTranslatedMath
 var THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'];
 
@@ -398,7 +422,7 @@ function translateMath(math, lang) {
     // IMPORTANT NOTE(danielhollas):These must come before decimal comma!
 
     // No thousand separator
-    { langs: ['ko'],
+    { langs: ['ko', 'ps'],
         regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1$2' },
 
     // Thousand separator as a dot
@@ -411,6 +435,12 @@ function translateMath(math, lang) {
     { langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
         regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
 
+    // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
+    // NOTE: At least in MathJax, this comma does not need braces,
+    // but it feels safer to have them here.
+    { langs: ['ps'],
+        regex: /([0-9])\.([0-9])/g, replace: '$1{،}$2' },
+
     // Decimal comma
     // IMPORTANT NOTE(danielhollas): This should be tha LAST regex!
     { langs: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv'],
@@ -422,6 +452,7 @@ function translateMath(math, lang) {
         }
     });
 
+    math = translateNumerals(math, lang);
     return math;
 }
 

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -358,6 +358,39 @@ function createTemplate(englishStr, translatedStr, lang) {
     }
 }
 
+/**
+ * Translates western-arabic numerals to others, see:
+ * https://en.wikipedia.org/wiki/Eastern_Arabic_numerals
+ *
+ * @param {string} math A math expression to translate for locale.
+ * @param {string} lang The locale of the translation language.
+ * @returns {string} The math expression with translated numerals.
+ */
+function translateNumerals(math, lang) {
+    // Perso-Arabic numerals (Used by Pashto)
+    // TODO(danielhollas): Move this const to a better place,
+    // pending PR #13
+    const PERSO_ARABIC_NUMERALS_LOCALES = ['ps'];
+    if (PERSO_ARABIC_NUMERALS_LOCALES.includes(lang)) {
+        math = math.replace(/1/g, '۱')
+                   .replace(/2/g, '۲')
+                   .replace(/3/g, '۳')
+                   .replace(/4/g, '۴')
+                   .replace(/5/g, '۵')
+                   .replace(/6/g, '۶')
+                   .replace(/7/g, '۷')
+                   .replace(/8/g, '۸')
+                   .replace(/9/g, '۹')
+                   .replace(/0/g, '۰');
+    }
+    // TODO(danielhollas): Implement Eastern-Arabic numerals
+    // (currently not in use by any team)
+    // Unicode code-points for these are different from the Perso-Arabic,
+    // even though some of the numbers look the same!
+
+    return math;
+}
+
 // This array is used both in translateMath and normalizeTranslatedMath
 const THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES = ['cs', 'fr', 'de',
       'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'];
@@ -402,7 +435,7 @@ function translateMath(math, lang) {
          // IMPORTANT NOTE(danielhollas):These must come before decimal comma!
 
          // No thousand separator
-         {langs: ['ko'],
+         {langs: ['ko', 'ps'],
             regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1$2'},
 
          // Thousand separator as a dot
@@ -414,6 +447,12 @@ function translateMath(math, lang) {
          // Thousand separator as a thin space
          {langs: THOUSAND_SEPARATOR_AS_THIN_SPACE_LOCALES,
             regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2'},
+
+         // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
+         // NOTE: At least in MathJax, this comma does not need braces,
+         // but it feels safer to have them here.
+         {langs: ['ps'],
+            regex: /([0-9])\.([0-9])/g, replace: '$1{،}$2'},
 
          // Decimal comma
          // IMPORTANT NOTE(danielhollas): This should be tha LAST regex!
@@ -428,6 +467,7 @@ function translateMath(math, lang) {
         }
     });
 
+    math = translateNumerals(math, lang);
     return math;
 }
 

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -529,6 +529,22 @@ describe('translateMath', function() {
         const outputStr = translateMath(englishStr, 'pt');
         assert.equal(outputStr, translatedStr);
     });
+
+    it('should translate western- to eastern-arabic numerals for pashto',
+    function() {
+        const englishStr = '1234567890';
+        const translatedStr = '۱۲۳۴۵۶۷۸۹۰';
+        const outputStr = translateMath(englishStr, 'ps');
+        assert.equal(outputStr, translatedStr);
+    });
+
+    it('should use arabic decimal comma and no thousand separator for pashto',
+    function() {
+        const englishStr = '1{,}234{,}567.890';
+        const translatedStr = '۱۲۳۴۵۶۷{،}۸۹۰';
+        const outputStr = translateMath(englishStr, 'ps');
+        assert.equal(outputStr, translatedStr);
+    });
 });
 
 describe('normalizeTranslatedMath', function() {


### PR DESCRIPTION
Add support for Eastern-Arabic numerals and Arabic decimal comma requested by Pashto (Afganistan) translators.

https://en.wikipedia.org/wiki/Arabic_(Unicode_block)

Perso-Arabic (used by Pashto): ۱۲۳۴۵۶۷۸۹۰
Eastern-Arabic: ١٢٣٤٥٦٧٨٩٠ (currently not implemented, no team is using them yet)

**TODO:**
- [x] **Implement separate function for converting numerals** 
- [x] **Double check we have the correct Unicode characters.**
- [x] **Check support for other numerals in KaTeX. Open issue in their repo.**
       [Issue already exists](https://github.com/Khan/KaTeX/issues/212). For now, we can fallback to MathJax. (tested in Translation Editor)
- [x] **Check how Arabic decimal comma behaves in (Ka/La)Tex/MathJax. Do we need extra braces?**
      In MathJax, Arabic decimal comma does not need extra braces. However, it feels safer to use them for now, we do not know how it will behave in KaTeX in the future, or what is the Latex behaviour.
- [x] For now, only Pashto is in locale list. Maybe others should be added as well?
  Waiting for answer from Urdu translator, but according to wiki, they might be fine with western numerals.
