### PR TITLE
Handle translations of repeating or colored decimals

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -410,6 +410,19 @@ function translateMath(math, lang) {
     var USThousandSeparatorRegex = new RegExp('([0-9])' + placeholder + '([0-9])(?=[0-9]{2})', 'g');
     var thousandSeparatorLocales = MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.concat(MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT, MATH_RULES_LOCALES.NO_THOUSAND_SEP);
 
+    // Definition of regex for decimal numbers
+    // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
+    // repeating decimals like '1/3 = 0.\\overline{3}'
+    //
+    // Colors currently used in KA strings taken from jipt-hack.jsx
+    // \\overline is handled elsewhere since it appears only
+    // on the right side of the decimal point
+    var katexColorMacros = ['blue', 'blueA', 'blueB', 'blueC', 'blueD', 'goldB', 'goldC', 'goldD', 'gray', 'grayD', 'grayE', 'grayF', 'green', 'greenB', 'greenC', 'greenD', 'greenE', 'kaBlue', 'maroonB', 'maroonC', 'maroonD', 'maroonE', 'orange', 'pink', 'purple', 'purpleA', 'purpleC', 'purpleD', 'purpleE', 'red', 'redA', 'redB', 'redC', 'redD', 'redE', 'tealA', 'tealB', 'tealC', 'tealD', 'tealE'].join('\\{)|(?:\\\\');
+
+    var integerPart = '((?:\\\\' + katexColorMacros + '\\{)?[0-9]\\}?)';
+    var decPart = '((?:\\\\overline\\{)|(?:\\\\' + katexColorMacros + '\\{)?[0-9])';
+    var decimalNumberRegex = new RegExp(integerPart + '\\.' + decPart, 'g');
+
     var mathTranslations = [
     // IMPORTANT NOTE: This MUST be the first regex
     // Convert thousand separators to a placeholder
@@ -420,13 +433,13 @@ function translateMath(math, lang) {
 
     // Decimal comma
     { langs: MATH_RULES_LOCALES.DECIMAL_COMMA,
-        regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2' },
+        regex: decimalNumberRegex, replace: '$1{,}$2' },
 
     // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
     // NOTE: At least in MathJax, this comma does not need braces,
     // but it feels safer to have them here.
     { langs: MATH_RULES_LOCALES.ARABIC_COMMA,
-        regex: /([0-9])\.([0-9])/g, replace: '$1{،}$2' },
+        regex: decimalNumberRegex, replace: '$1{،}$2' },
 
     // division sign as a colon
     { langs: MATH_RULES_LOCALES.DIV_AS_COLON,

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -417,11 +417,11 @@ function translateMath(math, lang) {
     // Colors currently used in KA strings taken from jipt-hack.jsx
     // \\overline is handled elsewhere since it appears only
     // on the right side of the decimal point
-    var katexColorMacros = ['blue', 'blueA', 'blueB', 'blueC', 'blueD', 'goldB', 'goldC', 'goldD', 'gray', 'grayD', 'grayE', 'grayF', 'green', 'greenB', 'greenC', 'greenD', 'greenE', 'kaBlue', 'maroonB', 'maroonC', 'maroonD', 'maroonE', 'orange', 'pink', 'purple', 'purpleA', 'purpleC', 'purpleD', 'purpleE', 'red', 'redA', 'redB', 'redC', 'redD', 'redE', 'tealA', 'tealB', 'tealC', 'tealD', 'tealE'].join('\\{)|(?:\\\\');
+    var katexColorMacros = ['blue', 'blueA', 'blueB', 'blueC', 'blueD', 'goldB', 'goldC', 'goldD', 'gray', 'grayD', 'grayE', 'grayF', 'green', 'greenB', 'greenC', 'greenD', 'greenE', 'kaBlue', 'maroonB', 'maroonC', 'maroonD', 'maroonE', 'orange', 'pink', 'purple', 'purpleA', 'purpleC', 'purpleD', 'purpleE', 'red', 'redA', 'redB', 'redC', 'redD', 'redE', 'tealA', 'tealB', 'tealC', 'tealD', 'tealE'].join('|');
 
-    var integerPart = '((?:\\\\' + katexColorMacros + '\\{)?[0-9]\\}?)';
-    var decPart = '((?:\\\\overline\\{)|(?:\\\\' + katexColorMacros + '\\{)?[0-9])';
-    var decimalNumberRegex = new RegExp(integerPart + '\\.' + decPart, 'g');
+    var integerPart = '[0-9]+|\\\\(?:' + katexColorMacros + ')\\{[0-9]+\\}';
+    var decPart = '[0-9]+|\\\\(?:overline|' + katexColorMacros + ')\\{[0-9]+\\}';
+    var decimalNumberRegex = new RegExp('(' + integerPart + ')\\.(' + decPart + ')', 'g');
 
     var mathTranslations = [
     // IMPORTANT NOTE: This MUST be the first regex

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -361,12 +361,12 @@ function createTemplate(englishStr, translatedStr, lang) {
  * TODO(danielhollas): Need to update this when new langs join translations
  */
 var MATH_RULES_LOCALES = {
-    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
+    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
     THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el'],
     NO_THOUSAND_SEP: ['ko', 'ps'],
-    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el'],
-    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da', 'lol'],
-    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'lol'],
+    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el'],
+    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da'],
+    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da'],
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps']

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -414,13 +414,20 @@ function translateMath(math, lang) {
     // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
     // repeating decimals like '1/3 = 0.\\overline{3}'
     //
-    // Colors currently used in KA strings taken from jipt-hack.jsx
+    // Colors currently used in KA strings taken from KaTeX definitions, see:
+    // https://github.com/KaTeX/KaTeX/blob/master/src/macros.js
+    //
     // \\overline is handled elsewhere since it appears only
     // on the right side of the decimal point
-    var katexColorMacros = ['blue', 'blueA', 'blueB', 'blueC', 'blueD', 'goldB', 'goldC', 'goldD', 'gray', 'grayD', 'grayE', 'grayF', 'green', 'greenB', 'greenC', 'greenD', 'greenE', 'kaBlue', 'maroonB', 'maroonC', 'maroonD', 'maroonE', 'orange', 'pink', 'purple', 'purpleA', 'purpleC', 'purpleD', 'purpleE', 'red', 'redA', 'redB', 'redC', 'redD', 'redE', 'tealA', 'tealB', 'tealC', 'tealD', 'tealE'].join('|');
+    //
+    // These colors are appended by optional [A-Z]? to match all definitions
+    // from KaTeX. This will form a superset of actually defined colors,
+    // but that hardly matters here and is more future-proof if new colors
+    // were defined at some point
+    var katexColorMacros = ['blue', 'gold', 'gray', 'mint', 'green', 'red', 'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen'].join('|');
 
-    var integerPart = '[0-9]+|\\\\(?:' + katexColorMacros + ')\\{[0-9]+\\}';
-    var decPart = '[0-9]+|\\\\(?:overline|' + katexColorMacros + ')\\{[0-9]+\\}';
+    var integerPart = '[0-9]+|\\\\(?:' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
+    var decPart = '[0-9]+|\\\\(?:overline|' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
     var decimalNumberRegex = new RegExp('(' + integerPart + ')\\.(' + decPart + ')', 'g');
 
     var mathTranslations = [

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -361,12 +361,12 @@ function createTemplate(englishStr, translatedStr, lang) {
  * TODO(danielhollas): Need to update this when new langs join translations
  */
 var MATH_RULES_LOCALES = {
-    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
+    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
     THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el'],
     NO_THOUSAND_SEP: ['ko', 'ps'],
-    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el'],
-    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da'],
-    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da'],
+    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el'],
+    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da', 'lol'],
+    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'lol'],
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps']

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -432,21 +432,23 @@ function translateMath(math, lang) {
     // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
     // repeating decimals like '1/3 = 0.\\overline{3}'
     //
-    // Colors currently used in KA strings taken from jipt-hack.jsx
+    // Colors currently used in KA strings taken from KaTeX definitions, see:
+    // https://github.com/KaTeX/KaTeX/blob/master/src/macros.js
+    //
     // \\overline is handled elsewhere since it appears only
     // on the right side of the decimal point
-    const katexColorMacros = ['blue', 'blueA', 'blueB', 'blueC', 'blueD',
-         'goldB', 'goldC', 'goldD', 'gray', 'grayD', 'grayE', 'grayF',
-         'green', 'greenB', 'greenC', 'greenD', 'greenE', 'kaBlue',
-         'maroonB', 'maroonC', 'maroonD', 'maroonE', 'orange', 'pink',
-         'purple', 'purpleA', 'purpleC', 'purpleD', 'purpleE',
-         'red', 'redA', 'redB', 'redC', 'redD', 'redE',
-         'tealA', 'tealB', 'tealC', 'tealD', 'tealE']
+    //
+    // These colors are appended by optional [A-Z]? to match all definitions
+    // from KaTeX. This will form a superset of actually defined colors,
+    // but that hardly matters here and is more future-proof if new colors
+    // were defined at some point
+    const katexColorMacros = ['blue', 'gold', 'gray', 'mint', 'green', 'red',
+         'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen']
          .join('|');
 
-    const integerPart = `[0-9]+|\\\\(?:${katexColorMacros})\\{[0-9]+\\}`;
+    const integerPart = `[0-9]+|\\\\(?:${katexColorMacros})[A-Z]?\\{[0-9]+\\}`;
     const decPart =
-       `[0-9]+|\\\\(?:overline|${katexColorMacros})\\{[0-9]+\\}`;
+       `[0-9]+|\\\\(?:overline|${katexColorMacros})[A-Z]?\\{[0-9]+\\}`;
     const decimalNumberRegex =
       new RegExp(`(${integerPart})\\.(${decPart})`, 'g');
 

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -448,7 +448,8 @@ function translateMath(math, lang) {
     const integerPart = `[0-9]+|\\\\(?:${katexColorMacros})\\{[0-9]+\\}`;
     const decPart =
        `[0-9]+|\\\\(?:overline|${katexColorMacros})\\{[0-9]+\\}`;
-    const decimalNumberRegex = new RegExp(`(${integerPart})\\.(${decPart})`, 'g');
+    const decimalNumberRegex =
+      new RegExp(`(${integerPart})\\.(${decPart})`, 'g');
 
     const mathTranslations = [
          // IMPORTANT NOTE: This MUST be the first regex

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -443,12 +443,12 @@ function translateMath(math, lang) {
          'purple', 'purpleA', 'purpleC', 'purpleD', 'purpleE',
          'red', 'redA', 'redB', 'redC', 'redD', 'redE',
          'tealA', 'tealB', 'tealC', 'tealD', 'tealE']
-         .join('\\{)|(?:\\\\');
+         .join('|');
 
-    const integerPart = `((?:\\\\${katexColorMacros}\\{)?[0-9]\\}?)`;
+    const integerPart = `[0-9]+|\\\\(?:${katexColorMacros})\\{[0-9]+\\}`;
     const decPart =
-       `((?:\\\\overline\\{)|(?:\\\\${katexColorMacros}\\{)?[0-9])`;
-    const decimalNumberRegex = new RegExp(`${integerPart}\\.${decPart}`, 'g');
+       `[0-9]+|\\\\(?:overline|${katexColorMacros})\\{[0-9]+\\}`;
+    const decimalNumberRegex = new RegExp(`(${integerPart})\\.(${decPart})`, 'g');
 
     const mathTranslations = [
          // IMPORTANT NOTE: This MUST be the first regex

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -428,6 +428,27 @@ function translateMath(math, lang) {
             .concat(MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
             MATH_RULES_LOCALES.NO_THOUSAND_SEP);
 
+    // Definition of regex for decimal numbers
+    // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
+    // repeating decimals like '1/3 = 0.\\overline{3}'
+    //
+    // Colors currently used in KA strings taken from jipt-hack.jsx
+    // \\overline is handled elsewhere since it appears only
+    // on the right side of the decimal point
+    const katexColorMacros = ['blue', 'blueA', 'blueB', 'blueC', 'blueD',
+         'goldB', 'goldC', 'goldD', 'gray', 'grayD', 'grayE', 'grayF',
+         'green', 'greenB', 'greenC', 'greenD', 'greenE', 'kaBlue',
+         'maroonB', 'maroonC', 'maroonD', 'maroonE', 'orange', 'pink',
+         'purple', 'purpleA', 'purpleC', 'purpleD', 'purpleE',
+         'red', 'redA', 'redB', 'redC', 'redD', 'redE',
+         'tealA', 'tealB', 'tealC', 'tealD', 'tealE']
+         .join('\\{)|(?:\\\\');
+
+    const integerPart = `((?:\\\\${katexColorMacros}\\{)?[0-9]\\}?)`;
+    const decPart =
+       `((?:\\\\overline\\{)|(?:\\\\${katexColorMacros}\\{)?[0-9])`;
+    const decimalNumberRegex = new RegExp(`${integerPart}\\.${decPart}`, 'g');
+
     const mathTranslations = [
          // IMPORTANT NOTE: This MUST be the first regex
          // Convert thousand separators to a placeholder
@@ -438,13 +459,13 @@ function translateMath(math, lang) {
 
          // Decimal comma
          {langs: MATH_RULES_LOCALES.DECIMAL_COMMA,
-            regex: /([0-9])\.([0-9])/g, replace: '$1{,}$2'},
+            regex: decimalNumberRegex, replace: '$1{,}$2'},
 
          // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
          // NOTE: At least in MathJax, this comma does not need braces,
          // but it feels safer to have them here.
          {langs: MATH_RULES_LOCALES.ARABIC_COMMA,
-            regex: /([0-9])\.([0-9])/g, replace: '$1{،}$2'},
+            regex: decimalNumberRegex, replace: '$1{،}$2'},
 
          // division sign as a colon
          {langs: MATH_RULES_LOCALES.DIV_AS_COLON,

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -364,14 +364,15 @@ function createTemplate(englishStr, translatedStr, lang) {
  * TODO(danielhollas): Need to update this when new langs join translations
  */
 const MATH_RULES_LOCALES = {
-    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de',
+    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol',
          'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
     THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el'],
     NO_THOUSAND_SEP: ['ko', 'ps'],
-    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr',
+    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol',
             'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el'],
-    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da'],
-    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da'],
+    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da',
+            'lol'],
+    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'lol'],
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -364,15 +364,14 @@ function createTemplate(englishStr, translatedStr, lang) {
  * TODO(danielhollas): Need to update this when new langs join translations
  */
 const MATH_RULES_LOCALES = {
-    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol',
+    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de',
          'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
     THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el'],
     NO_THOUSAND_SEP: ['ko', 'ps'],
-    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol',
+    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr',
             'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el'],
-    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da',
-            'lol'],
-    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'lol'],
+    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da'],
+    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da'],
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -613,7 +613,7 @@ describe('translateMath', function() {
         const englishStr =
            '\\blue{13}.\\tealE{3} \\tealE{9}.\\blue{4} \\redA{0}.\\red{33}';
         let translatedStr =
-           '\\blue{13}{,}\\tealE{3} \\tealE{9}{,}\\blue{4} \\redA{0}{,}\\red{33}';
+         '\\blue{13}{,}\\tealE{3} \\tealE{9}{,}\\blue{4} \\redA{0}{,}\\red{33}';
 
         MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
             const outputStr = translateMath(englishStr, locale);
@@ -621,14 +621,14 @@ describe('translateMath', function() {
         });
 
         translatedStr =
-           '\\blue{۱۳}{،}\\tealE{۳} \\tealE{۹}{،}\\blue{۴} \\redA{۰}{،}\\red{۳۳}';
+         '\\blue{۱۳}{،}\\tealE{۳} \\tealE{۹}{،}\\blue{۴} \\redA{۰}{،}\\red{۳۳}';
         MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
             const outputStr = translateMath(englishStr, locale);
             assert.equal(outputStr, translatedStr);
         });
     });
 
-    it('should NOT translate decimals wrapped in other tex commands', function() {
+    it('should NOT translate decimals wrapped in any tex commands', function() {
         const englishStr = '\\hat{1}.\\tealE{3} \\tealE{9}.\\hat{4}';
         let translatedStr = englishStr;
 

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -611,9 +611,9 @@ describe('translateMath', function() {
 
     it('should translate decimals wrapped in color commands', function() {
         const englishStr =
-           '\\blue{1}.\\tealE{3} \\tealE{9}.\\blue{4} \\redA{0}.\\red{3}';
+           '\\blue{13}.\\tealE{3} \\tealE{9}.\\blue{4} \\redA{0}.\\red{33}';
         let translatedStr =
-           '\\blue{1}{,}\\tealE{3} \\tealE{9}{,}\\blue{4} \\redA{0}{,}\\red{3}';
+           '\\blue{13}{,}\\tealE{3} \\tealE{9}{,}\\blue{4} \\redA{0}{,}\\red{33}';
 
         MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
             const outputStr = translateMath(englishStr, locale);
@@ -621,7 +621,23 @@ describe('translateMath', function() {
         });
 
         translatedStr =
-           '\\blue{۱}{،}\\tealE{۳} \\tealE{۹}{،}\\blue{۴} \\redA{۰}{،}\\red{۳}';
+           '\\blue{۱۳}{،}\\tealE{۳} \\tealE{۹}{،}\\blue{۴} \\redA{۰}{،}\\red{۳۳}';
+        MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
+    });
+
+    it('should NOT translate decimals wrapped in other tex commands', function() {
+        const englishStr = '\\hat{1}.\\tealE{3} \\tealE{9}.\\hat{4}';
+        let translatedStr = englishStr;
+
+        MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
+
+        translatedStr = '\\hat{۱}.\\tealE{۳} \\tealE{۹}.\\hat{۴}';
         MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
             const outputStr = translateMath(englishStr, locale);
             assert.equal(outputStr, translatedStr);

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -592,6 +592,42 @@ describe('translateMath', function() {
         const outputStr = translateMath(englishStr, 'ps');
         assert.equal(outputStr, translatedStr);
     });
+
+    it('should translate repeating decimal numbers', function() {
+        const englishStr = '1.\\overline{3} + 9.\\overline{44}';
+        let translatedStr = '1{,}\\overline{3} + 9{,}\\overline{44}';
+
+        MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
+
+        translatedStr = '۱{،}\\overline{۳} + ۹{،}\\overline{۴۴}';
+        MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
+    });
+
+    it('should translate decimals wrapped in color commands', function() {
+        const englishStr =
+           '\\blue{1}.\\tealE{3} \\tealE{9}.\\blue{4} \\redA{0}.\\red{3}';
+        let translatedStr =
+           '\\blue{1}{,}\\tealE{3} \\tealE{9}{,}\\blue{4} \\redA{0}{,}\\red{3}';
+
+        MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
+
+        translatedStr =
+           '\\blue{۱}{،}\\tealE{۳} \\tealE{۹}{،}\\blue{۴} \\redA{۰}{،}\\red{۳}';
+        MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
+            const outputStr = translateMath(englishStr, locale);
+            assert.equal(outputStr, translatedStr);
+        });
+    });
+
 });
 
 describe('normalizeTranslatedMath', function() {


### PR DESCRIPTION
The previous regex for decimal numbers could not handle cases where these numbers are wrapped in tex macros. This occurs e.g. for repeating decimals like `0.\\overline{3}` or colored decimals
like `\green{3}.\blue{4}`
Fixes #17.

Tracking JIRA ticket: https://khanacademy.atlassian.net/browse/IC-329

In my approach I explicitly list the katex macros. Helpfully, I could copy all existing color commands from the KA corpus from the list of tex commands in `jipt_hack.js` and from list of color macros from KaTeX itself.
