### PR TITLE
FIX grouping of \text {} with extra space

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -68,8 +68,13 @@ function stringToGroupKey(str) {
     var texts = maths.map(function (math) {
         var result = [];
 
-        allMatches(math, /\\text(?:bf)?\s*{([^}]*)}/g, function (matches) {
-            return result.push(matches[1]);
+        var regex = new RegExp(TEXT_REGEX.source + '|' + TEXTBF_REGEX.source, 'g');
+
+        allMatches(math, regex, function (matches) {
+            return result.push(
+            // TEXT_REGEX capture group is at index 1 and TEXTBF_REGEX at
+            // index 2. One of the groups is expected to be `undefined`.
+            matches[1] || matches[2]);
         });
 
         // The natural language text is sorted so that even if the formula is

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -68,7 +68,7 @@ function stringToGroupKey(str) {
     var texts = maths.map(function (math) {
         var result = [];
 
-        allMatches(math, /\\text(?:bf)?{([^}]*)}/g, function (matches) {
+        allMatches(math, /\\text(?:bf)?\s*{([^}]*)}/g, function (matches) {
             return result.push(matches[1]);
         });
 

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -66,7 +66,7 @@ function stringToGroupKey(str) {
     const texts = maths.map((math) => {
         const result = [];
 
-        allMatches(math, /\\text(?:bf)?{([^}]*)}/g,
+        allMatches(math, /\\text(?:bf)?\s*{([^}]*)}/g,
             (matches) => result.push(matches[1]));
 
         // The natural language text is sorted so that even if the formula is

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -66,8 +66,14 @@ function stringToGroupKey(str) {
     const texts = maths.map((math) => {
         const result = [];
 
-        allMatches(math, /\\text(?:bf)?\s*{([^}]*)}/g,
-            (matches) => result.push(matches[1]));
+        const regex = new RegExp(
+            `${TEXT_REGEX.source}|${TEXTBF_REGEX.source}`, 'g');
+
+        allMatches(math, regex,
+            (matches) => result.push(
+                // TEXT_REGEX capture group is at index 1 and TEXTBF_REGEX at
+                // index 2. One of the groups is expected to be `undefined`.
+                matches[1] || matches[2]));
 
         // The natural language text is sorted so that even if the formula is
         // different and the natural language text is in a different order

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -193,6 +193,30 @@ describe('TranslationAssistant', function() {
             assertSuggestions(allItems, itemsToTranslate, translatedStrs);
         });
 
+        it('should return null when there\'s nl text inside \\text{}',
+        function() {
+            const allItems = [];
+            const itemsToTranslate = [{
+                englishStr: '$\\text {simplify } 3x = 9$',
+                translatedStr: '',
+            }];
+            const translatedStrs = [null];
+
+            assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+        });
+
+        it('should return null when there\'s nl text inside \\textbf{}',
+        function() {
+            const allItems = [];
+            const itemsToTranslate = [{
+                englishStr: '$\\textbf {simplify } 3x = 9$',
+                translatedStr: '',
+            }];
+            const translatedStrs = [null];
+
+            assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+        });
+
         it('should return the same math', function() {
             const allItems = [];
             const itemsToTranslate = [
@@ -1589,7 +1613,7 @@ describe('normalizeString', function() {
             '{"str":"__MATH__ and __MATH__","texts":[["red"],["blue"]]}');
 
         assert.equal(
-            stringToGroupKey('${\\text{red} + \\textbf{blue}$ and $1 + 2$'),
+            stringToGroupKey('${\\text {red} + \\textbf {blue}$ and $1 + 2$'),
             '{"str":"__MATH__ and __MATH__","texts":[["blue","red"],[]]}');
     });
 });


### PR DESCRIPTION
Summary:
  This was a subtle regression that escaped existing tests.
  Strings with an extra space between `\text` or `\textbf` and `{` were not be grouped correctly.
  This only affected strings that had nl text only inside `\text`, in which case they would be grouped 
 together with 'only-math' strings, as if there was no text to translate. ST would then create a bad 
 suggestion.

Tracking JIRA: [IC-468](https://khanacademy.atlassian.net/browse/IC-123)

Test Plan:
  1. Go to:
    https://www.khanacademy.org/translations/edit/es/e/understand-equal-groups-as-multiplication/tree/uptream

  2. String https://crowdin.com/translate/khanacademy/26587/enus-es#4084054
  should be in Misc group.

  3. Strings https://crowdin.com/translate/khanacademy/43041/enus-es#6035089
  and https://crowdin.com/translate/khanacademy/26587/enus-es#4084053
  should have their own group.