### PR TITLE
FEATURE: Handle multiple math notations

### DIFF
--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -11,30 +11,35 @@
 'use strict';
 
 var MATH_RULES_LOCALES = {
-   // Number formats
-   THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
-   THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el', 'id'],
-   NO_THOUSAND_SEP: ['ko', 'ps', 'ka'],
-   DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka', 'ru'],
-   ARABIC_COMMA: ['ps'],
-   PERSO_ARABIC_NUMERALS: ['ps'],
-   // Notations for repeating decimals - 0.\overline{3}
-   // 0.(3)
-   OVERLINE_AS_DOT: ['bn'],
-   // 0.\dot{3}
-   OVERLINE_AS_PARENS: ['az', 'pt-pt'],
-   // Binary operators
-   // TODO(danielhollas):remove 'bg' from TIMES_AS_CDOT
-   // when \mathbin{.} becomes available for them
-   TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da', 'bg', 'lol'],
-   DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'pl', 'lol', 'id', 'pt-pt', 'ru', 'nb'],
-   // Trig functions
-   SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
-   TAN_AS_TG: ['az', 'bg', 'hu', 'hy', 'pt', 'pt-pt'],
-   COT_AS_COTG: ['pt', 'pt-pt'],
-   COT_AS_CTG: ['az', 'hu', 'hy', 'bg'],
-   CSC_AS_COSEC: ['az', 'bg', 'bn'],
-   CSC_AS_COSSEC: ['pt', 'pt-pt']
+    // Number formats
+    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
+    THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el', 'id'],
+    NO_THOUSAND_SEP: ['ko', 'ps', 'ka'],
+    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka', 'ru', 'ta'],
+    ARABIC_COMMA: ['ps'],
+    PERSO_ARABIC_NUMERALS: ['ps'],
+    // Notations for repeating decimals - 0.\overline{3}
+    // 0.(3)
+    OVERLINE_AS_DOT: ['bn'],
+    // 0.\dot{3}
+    OVERLINE_AS_PARENS: ['az', 'pt-pt'],
+    // Binary operators
+    // TODO(danielhollas):remove 'bg' from TIMES_AS_CDOT
+    // when \mathbin{.} becomes available for them
+    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da', 'bg'],
+    CDOT_AS_TIMES: ['fr', 'ps', 'pt-pt', 'ta'],
+    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'pl', 'it', 'pt-pt', 'ru', 'nb'],
+    // Trig functions
+    SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
+    TAN_AS_TG: ['az', 'bg', 'hu', 'hy', 'pt', 'pt-pt'],
+    COT_AS_COTG: ['pt', 'pt-pt'],
+    COT_AS_CTG: ['az', 'hu', 'hy', 'bg'],
+    CSC_AS_COSEC: ['az', 'bg', 'bn'],
+    CSC_AS_COSSEC: ['pt', 'pt-pt'],
+    // Rules conditional on the translated template
+    MAYBE_DIV_AS_COLON: ['id', 'lol'],
+    MAYBE_TIMES_AS_CDOT: ['az', 'bn', 'el', 'hi', 'hy', 'id', 'it', 'ja', 'ka', 'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
+    MAYBE_CDOT_AS_TIMES: ['az', 'bn', 'el', 'hi', 'hy', 'id', 'it', 'ja', 'ka', 'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol']
 };
 
 /**
@@ -46,16 +51,16 @@ var MATH_RULES_LOCALES = {
  * @returns {string} The math expression with translated numerals.
  */
 function translateNumerals(math, lang) {
-   // Perso-Arabic numerals (Used by Pashto)
-   if (MATH_RULES_LOCALES.PERSO_ARABIC_NUMERALS.includes(lang)) {
-      math = math.replace(/1/g, '۱').replace(/2/g, '۲').replace(/3/g, '۳').replace(/4/g, '۴').replace(/5/g, '۵').replace(/6/g, '۶').replace(/7/g, '۷').replace(/8/g, '۸').replace(/9/g, '۹').replace(/0/g, '۰');
-   }
-   // TODO(danielhollas): Implement Eastern-Arabic numerals
-   // (currently not in use by any team)
-   // Unicode code-points for these are different from the Perso-Arabic,
-   // even though some of the numbers look the same!
+    // Perso-Arabic numerals (Used by Pashto)
+    if (MATH_RULES_LOCALES.PERSO_ARABIC_NUMERALS.includes(lang)) {
+        math = math.replace(/1/g, '۱').replace(/2/g, '۲').replace(/3/g, '۳').replace(/4/g, '۴').replace(/5/g, '۵').replace(/6/g, '۶').replace(/7/g, '۷').replace(/8/g, '۸').replace(/9/g, '۹').replace(/0/g, '۰');
+    }
+    // TODO(danielhollas): Implement Eastern-Arabic numerals
+    // (currently not in use by any team)
+    // Unicode code-points for these are different from the Perso-Arabic,
+    // even though some of the numbers look the same!
 
-   return math;
+    return math;
 }
 
 /**
@@ -70,88 +75,88 @@ function translateNumerals(math, lang) {
  */
 function translateNumbers(math, lang) {
 
-   // These consts are used only here for manipulating thousand separator
-   var placeholder = 'THSEP';
-   var USThousandSeparatorRegex = new RegExp('([0-9])' + placeholder + '([0-9])(?=[0-9]{2})', 'g');
-   var thousandSeparatorLocales = [].concat(MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE, MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT, MATH_RULES_LOCALES.NO_THOUSAND_SEP);
+    // These consts are used only here for manipulating thousand separator
+    var placeholder = 'THSEP';
+    var USThousandSeparatorRegex = new RegExp('([0-9])' + placeholder + '([0-9])(?=[0-9]{2})', 'g');
+    var thousandSeparatorLocales = [].concat(MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE, MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT, MATH_RULES_LOCALES.NO_THOUSAND_SEP);
 
-   // Definition of regex for decimal numbers
-   // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
-   // repeating decimals like '1/3 = 0.\\overline{3}'
-   //
-   // Colors currently used in KA strings taken from KaTeX definitions, see:
-   // https://github.com/KaTeX/KaTeX/blob/master/src/macros.js
-   //
-   // \\overline is handled elsewhere since it appears only
-   // on the right side of the decimal point
-   //
-   // These colors are appended by optional [A-Z]? to match all definitions
-   // from KaTeX. This will form a superset of actually defined colors,
-   // but that hardly matters here and is more future-proof if new colors
-   // were defined at some point
-   var katexColorMacros = ['blue', 'gold', 'gray', 'mint', 'green', 'red', 'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen'].join('|');
+    // Definition of regex for decimal numbers
+    // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
+    // repeating decimals like '1/3 = 0.\\overline{3}'
+    //
+    // Colors currently used in KA strings taken from KaTeX definitions, see:
+    // https://github.com/KaTeX/KaTeX/blob/master/src/macros.js
+    //
+    // \\overline is handled elsewhere since it appears only
+    // on the right side of the decimal point
+    //
+    // These colors are appended by optional [A-Z]? to match all definitions
+    // from KaTeX. This will form a superset of actually defined colors,
+    // but that hardly matters here and is more future-proof if new colors
+    // were defined at some point
+    var katexColorMacros = ['blue', 'gold', 'gray', 'mint', 'green', 'red', 'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen'].join('|');
 
-   var integerPart = '[0-9]+|\\\\(?:' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
-   var decPart = '[0-9]+|\\\\(?:overline|' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
-   var decimalNumberRegex = new RegExp('(' + integerPart + ')\\.(' + decPart + ')', 'g');
+    var integerPart = '[0-9]+|\\\\(?:' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
+    var decPart = '[0-9]+|\\\\(?:overline|' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
+    var decimalNumberRegex = new RegExp('(' + integerPart + ')\\.(' + decPart + ')', 'g');
 
-   var mathTranslations = [
-   // IMPORTANT NOTE: This MUST be the first regex
-   // Convert thousand separators to a placeholder
-   // to prevent interactions with decimal commas
-   { langs: thousandSeparatorLocales,
-      regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g,
-      replace: '$1' + placeholder + '$2' },
+    var mathTranslations = [
+    // IMPORTANT NOTE: This MUST be the first regex
+    // Convert thousand separators to a placeholder
+    // to prevent interactions with decimal commas
+    { langs: thousandSeparatorLocales,
+        regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g,
+        replace: '$1' + placeholder + '$2' },
 
-   // Decimal comma
-   { langs: MATH_RULES_LOCALES.DECIMAL_COMMA,
-      regex: decimalNumberRegex, replace: '$1{,}$2' },
+    // Decimal comma
+    { langs: MATH_RULES_LOCALES.DECIMAL_COMMA,
+        regex: decimalNumberRegex, replace: '$1{,}$2' },
 
-   // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
-   // NOTE: At least in MathJax, this comma does not need braces,
-   // but it feels safer to have them here.
-   { langs: MATH_RULES_LOCALES.ARABIC_COMMA,
-      regex: decimalNumberRegex, replace: '$1{،}$2' },
+    // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
+    // NOTE: At least in MathJax, this comma does not need braces,
+    // but it feels safer to have them here.
+    { langs: MATH_RULES_LOCALES.ARABIC_COMMA,
+        regex: decimalNumberRegex, replace: '$1{،}$2' },
 
-   // Different notations for repeating decimals
-   { langs: MATH_RULES_LOCALES.OVERLINE_AS_PARENS,
-      regex: /\\overline\{(\d+)\}/g, replace: '($1)' },
+    // Different notations for repeating decimals
+    { langs: MATH_RULES_LOCALES.OVERLINE_AS_PARENS,
+        regex: /\\overline\{(\d+)\}/g, replace: '($1)' },
 
-   // MATH_RULES_LOCALES.OVERLINE_AS_DOT needs special handling
+    // MATH_RULES_LOCALES.OVERLINE_AS_DOT needs special handling
 
-   // Thousand separator notations
+    // Thousand separator notations
 
-   // No thousand separator
-   { langs: MATH_RULES_LOCALES.NO_THOUSAND_SEP,
-      regex: USThousandSeparatorRegex, replace: '$1$2' },
+    // No thousand separator
+    { langs: MATH_RULES_LOCALES.NO_THOUSAND_SEP,
+        regex: USThousandSeparatorRegex, replace: '$1$2' },
 
-   // Thousand separator as a dot
-   { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
-      regex: USThousandSeparatorRegex, replace: '$1.$2' },
+    // Thousand separator as a dot
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
+        regex: USThousandSeparatorRegex, replace: '$1.$2' },
 
-   // Thousand separator as a thin space (\, in Tex)
-   { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
-      regex: USThousandSeparatorRegex, replace: '$1\\,$2' }];
+    // Thousand separator as a thin space (\, in Tex)
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        regex: USThousandSeparatorRegex, replace: '$1\\,$2' }];
 
-   mathTranslations.forEach(function (element) {
-      if (element.langs.includes(lang)) {
-         math = math.replace(element.regex, element.replace);
-      }
-   });
+    mathTranslations.forEach(function (element) {
+        if (element.langs.includes(lang)) {
+            math = math.replace(element.regex, element.replace);
+        }
+    });
 
-   // Special handling for OVERLINE_AS_DOT rule for repeating decimals
-   // we need to translate 0.\overline{12} as 0.\dot{1}\dot{2}
-   if (MATH_RULES_LOCALES.OVERLINE_AS_DOT.includes(lang)) {
-      var fromRegex = new RegExp(/\\overline\{(\d+)\}/, 'g');
-      var match = undefined;
-      while ((match = fromRegex.exec(math)) !== null) {
-         var numbers = match[1];
-         var replace = numbers.replace(/\d/g, '\\dot{$&}');
-         math = math.replace(match[0], replace);
-      }
-   }
+    // Special handling for OVERLINE_AS_DOT rule for repeating decimals
+    // we need to translate 0.\overline{12} as 0.\dot{1}\dot{2}
+    if (MATH_RULES_LOCALES.OVERLINE_AS_DOT.includes(lang)) {
+        var fromRegex = new RegExp(/\\overline\{(\d+)\}/, 'g');
+        var match = undefined;
+        while ((match = fromRegex.exec(math)) !== null) {
+            var numbers = match[1];
+            var replace = numbers.replace(/\d/g, '\\dot{$&}');
+            math = math.replace(match[0], replace);
+        }
+    }
 
-   return math;
+    return math;
 }
 
 /**
@@ -164,41 +169,45 @@ function translateNumbers(math, lang) {
  */
 function translateMathOperators(math, lang) {
 
-   var mathTranslations = [
-   // BINARY OPERATORS
-   // division sign as a colon
-   { langs: MATH_RULES_LOCALES.DIV_AS_COLON,
-      regex: /\\div/g, replace: '\\mathbin{:}' },
+    var mathTranslations = [
+    // BINARY OPERATORS
+    // division sign as a colon
+    { langs: MATH_RULES_LOCALES.DIV_AS_COLON,
+        regex: /\\div/g, replace: '\\mathbin{:}' },
 
-   // multiplication sign as a centered dot
-   { langs: MATH_RULES_LOCALES.TIMES_AS_CDOT,
-      regex: /\\times/g, replace: '\\cdot' },
+    // multiplication sign as a centered dot
+    { langs: MATH_RULES_LOCALES.TIMES_AS_CDOT,
+        regex: /\\times/g, replace: '\\cdot' },
 
-   // multiplication sign as a simple dot, a Bulgarian specialty
-   // TODO(danielhollas): not yet allowed by the linter
-   // TODO(danielhollas): add a test for this case
-   //{langs: ['bg'],
-   //   regex: /\\times/g, replace: '\\mathbin{.}'},
+    // multiplication sign as x
+    { langs: MATH_RULES_LOCALES.CDOT_AS_TIMES,
+        regex: /\\cdot/g, replace: '\\times' },
 
-   // TRIG FUNCTIONS
-   // NOTE(danielhollas): In principle, some might want to use
-   // e.g. sin^{-1} instead of arcsin, but we'll keep it simple
-   // and that notation is confusing anyway (1/sin or arcsin?)
-   { langs: MATH_RULES_LOCALES.SIN_AS_SEN,
-      regex: /\\(arc)?sin/g, replace: '\\operatorname{$1sen}' }, { langs: MATH_RULES_LOCALES.TAN_AS_TG,
-      regex: /\\(arc)?tan/g, replace: '\\operatorname{$1tg}' }, { langs: MATH_RULES_LOCALES.COT_AS_COTG,
-      regex: /\\(arc)?cot/g, replace: '\\operatorname{$1cotg}' }, { langs: MATH_RULES_LOCALES.COT_AS_CTG,
-      regex: /\\(arc)?cot/g, replace: '\\operatorname{$1ctg}' }, { langs: MATH_RULES_LOCALES.CSC_AS_COSEC,
-      regex: /\\(arc)?csc/g, replace: '\\operatorname{$1cosec}' }, { langs: MATH_RULES_LOCALES.CSC_AS_COSSEC,
-      regex: /\\(arc)?csc/g, replace: '\\operatorname{$1cossec}' }];
+    // multiplication sign as a simple dot, a Bulgarian specialty
+    // TODO(danielhollas): not yet allowed by the linter
+    // TODO(danielhollas): add a test for this case
+    //{langs: ['bg'],
+    //   regex: /\\times/g, replace: '\\mathbin{.}'},
 
-   mathTranslations.forEach(function (element) {
-      if (element.langs.includes(lang)) {
-         math = math.replace(element.regex, element.replace);
-      }
-   });
+    // TRIG FUNCTIONS
+    // NOTE(danielhollas): In principle, some might want to use
+    // e.g. sin^{-1} instead of arcsin, but we'll keep it simple
+    // and that notation is confusing anyway (1/sin or arcsin?)
+    { langs: MATH_RULES_LOCALES.SIN_AS_SEN,
+        regex: /\\(arc)?sin/g, replace: '\\operatorname{$1sen}' }, { langs: MATH_RULES_LOCALES.TAN_AS_TG,
+        regex: /\\(arc)?tan/g, replace: '\\operatorname{$1tg}' }, { langs: MATH_RULES_LOCALES.COT_AS_COTG,
+        regex: /\\(arc)?cot/g, replace: '\\operatorname{$1cotg}' }, { langs: MATH_RULES_LOCALES.COT_AS_CTG,
+        regex: /\\(arc)?cot/g, replace: '\\operatorname{$1ctg}' }, { langs: MATH_RULES_LOCALES.CSC_AS_COSEC,
+        regex: /\\(arc)?csc/g, replace: '\\operatorname{$1cosec}' }, { langs: MATH_RULES_LOCALES.CSC_AS_COSSEC,
+        regex: /\\(arc)?csc/g, replace: '\\operatorname{$1cossec}' }];
 
-   return math;
+    mathTranslations.forEach(function (element) {
+        if (element.langs.includes(lang)) {
+            math = math.replace(element.regex, element.replace);
+        }
+    });
+
+    return math;
 }
 
 /**
@@ -210,11 +219,11 @@ function translateMathOperators(math, lang) {
  * @returns {string} The translated math expression.
  */
 function translateMath(math, lang) {
-   // The order here should not matter
-   math = translateMathOperators(math, lang);
-   math = translateNumbers(math, lang);
-   math = translateNumerals(math, lang);
-   return math;
+    // The order here should not matter
+    math = translateMathOperators(math, lang);
+    math = translateNumbers(math, lang);
+    math = translateNumerals(math, lang);
+    return math;
 }
 
 /**
@@ -230,54 +239,99 @@ function translateMath(math, lang) {
  */
 function normalizeTranslatedMath(math, lang) {
 
-   var mathNormalizations = [
-   // Strip superfluous curly braces around \\,
-   // which is used as thousand separator in some locales
-   // i.e. 10{,}200 can be translated as 10{\\,}200, but the curly
-   // braces are not really needed.
-   // To understand why braces are needed around comma, see:
-   // https://tex.stackexchange.com/questions/303110/avoid-space-after-thousands-separator-in-math-mode#303127
-   { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
-      regex: /([0-9])\{\\,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
+    var mathNormalizations = [
+    // Strip superfluous curly braces around \\,
+    // which is used as thousand separator in some locales
+    // i.e. 10{,}200 can be translated as 10{\\,}200, but the curly
+    // braces are not really needed.
+    // To understand why braces are needed around comma, see:
+    // https://tex.stackexchange.com/questions/303110/avoid-space-after-thousands-separator-in-math-mode#303127
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        regex: /([0-9])\{\\,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
 
-   // Strip extra braces around a dot as a thousand separator
-   { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
-      regex: /([0-9])\{\.\}([0-9])(?=[0-9]{2})/g, replace: '$1.$2' },
+    // Strip extra braces around a dot as a thousand separator
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
+        regex: /([0-9])\{\.\}([0-9])(?=[0-9]{2})/g, replace: '$1.$2' },
 
-   // Allow translators to use a full space (~ in LaTeX)
-   // (but TA will always suggest thin space \,)
-   // We cannot allow a literal space here, cause Tex would ignore it
-   { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
-      regex: /([0-9])\{?~\}?([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
+    // Allow translators to use a full space (~ in LaTeX)
+    // (but TA will always suggest thin space \,)
+    // We cannot allow a literal space here, cause Tex would ignore it
+    { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        regex: /([0-9])\{?~\}?([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2' },
 
-   // KaTeX supports more trig functions then default LaTeX
-   // (\tg, \arctg, \cotg \ctg, \cosec)
-   // but we're using \operatorname for them as well in translateMath()
-   // In principle, they cannot be used by translators at the moment
-   // because they are blocked by linter. But we will permit them here
-   // in case the linter limitation is lifted in the future.
-   // https://katex.org/?data=%7B%22displayMode%22%3Atrue%2C%22leqno%22%3Afalse%2C%22fleqn%22%3Afalse%2C%22throwOnError%22%3Atrue%2C%22errorColor%22%3A%22%23cc0000%22%2C%22strict%22%3A%22warn%22%2C%22trust%22%3Afalse%2C%22macros%22%3A%7B%22%5C%5Cf%22%3A%22f(%231)%22%7D%2C%22code%22%3A%22%25%20%5C%5Cf%20is%20defined%20as%20f(%231)%20using%20the%20macro%5Cn%5C%5Csin%20%5C%5Carcsin%20%5C%5Ccos%20%5C%5Carccos%20%5C%5C%5C%5C%20%5C%5Ctan%20%5C%5Carctan%20%5C%5Ctg%20%5C%5Carctg%20%5C%5C%5C%5C%5Cn%5C%5Ccot%20%5C%5Ccotg%20%5C%5Cctg%20%5C%5Coperatorname%7Barccot%7D%20%5C%5C%5C%5C%5Cn%5C%5Ccsc%20%5C%5Ccosec%20%5C%5Coperatorname%7Barccsc%7D%20%5C%5C%5C%5C%5Cn%5C%5Coperatorname%7Bsen%7D%7Bx%7D%20%5C%5Csin%7Bx%7D%20%5C%5Csin%20x%22%7D
-   { langs: Array.from(new Set([].concat(MATH_RULES_LOCALES.TAN_AS_TG, MATH_RULES_LOCALES.COT_AS_COTG, MATH_RULES_LOCALES.COT_AS_CTG, MATH_RULES_LOCALES.CSC_AS_COSEC))),
-      regex: /\\(tg|arctg|cotg|ctg|cosec)/g,
-      replace: '\\operatorname{$1}' }];
+    // KaTeX supports more trig functions then default LaTeX
+    // (\tg, \arctg, \cotg \ctg, \cosec)
+    // but we're using \operatorname for them as well in translateMath()
+    // In principle, they cannot be used by translators at the moment
+    // because they are blocked by linter. But we will permit them here
+    // in case the linter limitation is lifted in the future.
+    // https://katex.org/?data=%7B%22displayMode%22%3Atrue%2C%22leqno%22%3Afalse%2C%22fleqn%22%3Afalse%2C%22throwOnError%22%3Atrue%2C%22errorColor%22%3A%22%23cc0000%22%2C%22strict%22%3A%22warn%22%2C%22trust%22%3Afalse%2C%22macros%22%3A%7B%22%5C%5Cf%22%3A%22f(%231)%22%7D%2C%22code%22%3A%22%25%20%5C%5Cf%20is%20defined%20as%20f(%231)%20using%20the%20macro%5Cn%5C%5Csin%20%5C%5Carcsin%20%5C%5Ccos%20%5C%5Carccos%20%5C%5C%5C%5C%20%5C%5Ctan%20%5C%5Carctan%20%5C%5Ctg%20%5C%5Carctg%20%5C%5C%5C%5C%5Cn%5C%5Ccot%20%5C%5Ccotg%20%5C%5Cctg%20%5C%5Coperatorname%7Barccot%7D%20%5C%5C%5C%5C%5Cn%5C%5Ccsc%20%5C%5Ccosec%20%5C%5Coperatorname%7Barccsc%7D%20%5C%5C%5C%5C%5Cn%5C%5Coperatorname%7Bsen%7D%7Bx%7D%20%5C%5Csin%7Bx%7D%20%5C%5Csin%20x%22%7D
+    { langs: Array.from(new Set([].concat(MATH_RULES_LOCALES.TAN_AS_TG, MATH_RULES_LOCALES.COT_AS_COTG, MATH_RULES_LOCALES.COT_AS_CTG, MATH_RULES_LOCALES.CSC_AS_COSEC))),
+        regex: /\\(tg|arctg|cotg|ctg|cosec)/g,
+        replace: '\\operatorname{$1}' }];
 
-   mathNormalizations.forEach(function (element) {
-      if (element.langs.includes(lang)) {
-         math = math.replace(element.regex, element.replace);
-      }
-   });
+    mathNormalizations.forEach(function (element) {
+        if (element.langs.includes(lang)) {
+            math = math.replace(element.regex, element.replace);
+        }
+    });
 
-   return math;
+    return math;
 }
 
-var MathTranslator = {};
+/**
+ * Maybe translate certain math notation to match the notation
+ * that the translator used in the template string.
+ *
+ * This is needed for cases where two or more translations are valid,
+ * e.g. \cdot versus \times, or where there's not a unique mapping from
+ * US notation (intervals and cartesian coordinates have the same notation
+ * in the US but different in many countries).
+ *
+ * The assumption here is that different math notations will not mingle
+ * in a single string, even though in principle a single string can very well
+ * contain both an interval (0,10) and cartesian point (0, 0) for example.
+ * Presumably, such cases are rare.
+ *
+ * Example: String '\\times' will be translated to '\\cdot' if and only if:
+ * 1. lang is in MAYBE_TIMES_AS_CDOT_LOCALES
+ * 2. the 'template' contains '\\cdot' at least once
+ * 3. the 'template' does NOT contain '\\times'
+ *
+ * @param {string} math A math expression to be translated
+ * @param {string} template User-translated template
+ * @param {string} lang The KA locale of the translation language.
+ * @returns {string} translated math expression.
+ */
+function maybeTranslateMath(math, template, lang) {
+    if (!template) {
+        return math;
+    }
 
-MathTranslator.translateMath = translateMath;
-MathTranslator.normalizeTranslatedMath = normalizeTranslatedMath;
-MathTranslator.MATH_RULES_LOCALES = MATH_RULES_LOCALES;
+    var maybeMathTranslations = [
+    // multiplication sign as a centered dot
+    { langs: MATH_RULES_LOCALES.MAYBE_TIMES_AS_CDOT,
+        regex: /\\times/g, replace: '\\cdot' },
+    // multiplication sign as x
+    { langs: MATH_RULES_LOCALES.MAYBE_CDOT_AS_TIMES,
+        regex: /\\cdot/g, replace: '\\times' },
+    // division sign as a colon
+    { langs: MATH_RULES_LOCALES.MAYBE_DIV_AS_COLON,
+        regex: /\\div/g, replace: '\\mathbin{:}' }];
+
+    maybeMathTranslations.forEach(function (el) {
+        if (el.langs.includes(lang) && template.includes(el.replace) && !template.match(el.regex)) {
+
+            math = math.replace(el.regex, el.replace);
+        }
+    });
+
+    return math;
+}
 
 module.exports = {
-   translateMath: translateMath,
-   normalizeTranslatedMath: normalizeTranslatedMath,
-   MATH_RULES_LOCALES: MATH_RULES_LOCALES
+    translateMath: translateMath,
+    maybeTranslateMath: maybeTranslateMath,
+    normalizeTranslatedMath: normalizeTranslatedMath,
+    MATH_RULES_LOCALES: MATH_RULES_LOCALES
 };

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -10,6 +10,7 @@ var _require = require('./math-translator');
 
 var translateMath = _require.translateMath;
 var normalizeTranslatedMath = _require.normalizeTranslatedMath;
+var maybeTranslateMath = _require.maybeTranslateMath;
 
 // Matches math delimited by $, e.g.
 // $x^2 + 2x + 1 = 0$
@@ -133,20 +134,28 @@ mathDictionary) {
     var outputs = translatedStr.match(findRegex) || [];
 
     if (findRegex === MATH_REGEX) {
-        inputs = inputs.map(function (input) {
-            return translateMath(input, lang);
-        }).map(function (input) {
-            return replaceTextInMath(input, mathDictionary);
-        });
+        (function () {
+            // Used in maybeTranslateMath() to pattern-match the translated math
+            // from the entire template
+            var allTranslatedMaths = outputs.join(' ');
+            inputs = inputs.map(function (input) {
+                return maybeTranslateMath(input, allTranslatedMaths, lang);
+            }).map(function (input) {
+                return translateMath(input, lang);
+            }).map(function (input) {
+                return replaceTextInMath(input, mathDictionary);
+            });
+        })();
     }
 
     var mapping = [];
 
     outputs.forEach(function (output, outputIndex) {
 
-        // NOTE(danielhollas): Currently, we will not offer smart translations
-        // if the user did not translate math according to our locale rules,
-        // normalizeTranslatedMath only handles some special cases.
+        // NOTE(danielhollas): Smart Translations will not be offered
+        // if translator did not translate math according to our locale rules,
+        // normalizeTranslatedMath only handles some special cases
+        // where we permit variations.
         if (findRegex === MATH_REGEX) {
             output = normalizeTranslatedMath(output, lang);
         }
@@ -220,6 +229,9 @@ function allMatches(text, regex, callback) {
 function getMathDictionary(englishStr, translatedStr, lang) {
     var inputs = englishStr.match(MATH_REGEX) || [];
     var outputs = translatedStr.match(MATH_REGEX) || [];
+    // Used in maybeTranslateMath() to pattern-match the translated math
+    // from the entire template
+    var allTranslatedMaths = outputs.join(' ');
 
     var inputMap = {};
     var outputMap = {};
@@ -227,6 +239,8 @@ function getMathDictionary(englishStr, translatedStr, lang) {
     var replaceRegexes = [[TEXT_REGEX, '__TEXT__'], [TEXTBF_REGEX, '__TEXTBF__']];
 
     inputs = inputs.map(function (input) {
+        return maybeTranslateMath(input, allTranslatedMaths, lang);
+    }).map(function (input) {
         return translateMath(input, lang);
     });
 
@@ -273,7 +287,7 @@ function getMathDictionary(englishStr, translatedStr, lang) {
             var regex = _ref5[1];
 
             if (match.test(key)) {
-                var _ret = (function () {
+                var _ret2 = (function () {
                     var input = inputMap[key];
 
                     if (!outputMap.hasOwnProperty(key)) {
@@ -310,7 +324,7 @@ function getMathDictionary(englishStr, translatedStr, lang) {
                     }
                 })();
 
-                if (typeof _ret === 'object') return _ret.v;
+                if (typeof _ret2 === 'object') return _ret2.v;
             }
         });
     });
@@ -347,6 +361,8 @@ function createTemplate(englishStr, translatedStr, lang) {
             lines: translatedLines.map(function (line) {
                 return line.replace(MATH_REGEX, '__MATH__').replace(GRAPHIE_REGEX, '__GRAPHIE__').replace(IMAGE_REGEX, '__IMAGE__').replace(WIDGET_REGEX, '__WIDGET__');
             }),
+            // Needed in maybeTranslateMath()
+            translatedMaths: translatedStr.match(MATH_REGEX) || [],
             mathMapping: {
                 englishToTranslated: getMapping(englishStr, translatedStr, lang, MATH_REGEX, translatedDictionary),
                 // This will be used by populateTemplate to validate that the
@@ -426,9 +442,9 @@ function replaceTextInMath(englishMath, dict) {
     for (var _iterator = Object.entries(dict), _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
         var _ref;
 
-        var _ret2 = _loop();
+        var _ret3 = _loop();
 
-        if (_ret2 === 'break') break;
+        if (_ret3 === 'break') break;
     }
     return translatedMath;
 }
@@ -478,14 +494,21 @@ function populateTemplate(template, englishStr, lang) {
     var images = englishStr.match(IMAGE_REGEX) || [];
     var widgets = englishStr.match(WIDGET_REGEX) || [];
 
+    // Used in maybeTranslateMath() to pattern-match the translated math
+    // from the entire template
+    var allTranslatedMaths = template.translatedMaths.join(' ');
+
     var mathIndex = 0;
     var graphieIndex = 0;
     var imageIndex = 0;
     var widgetIndex = 0;
 
     maths = maths.map(function (math) {
-        var result = translateMath(math, lang);
-        return replaceTextInMath(result, template.mathDictionary);
+        return maybeTranslateMath(math, allTranslatedMaths, lang);
+    }).map(function (math) {
+        return translateMath(math, lang);
+    }).map(function (math) {
+        return replaceTextInMath(math, template.mathDictionary);
     });
 
     return englishLines.map(function (englishLine, index) {
@@ -578,19 +601,14 @@ var TranslationAssistant = (function () {
             var normalStr = stringToGroupKey(englishStr);
             var normalObj = JSON.parse(normalStr);
 
-            // Translate items that are only math, a graphie, an image, or a
-            // widget.
+            // Return items that are only a graphie, an image, or a widget
+            // unchanged. Presumably, even if the translator changed
+            // a graphie link in one string, they will not want to use the same
+            // link in a different string.
+            // Widgets should never be changed.
             // TODO(kevinb) handle multiple non-nl_text items
-            if (/^(__MATH__|__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
-                if (normalObj.str === '__MATH__') {
-                    // Only translate the math if it doesn't include any
-                    // natural language text in \text and \textbf commands.
-                    if (englishStr.indexOf('\\text') === -1) {
-                        return [item, translateMath(englishStr, lang)];
-                    }
-                } else {
-                    return [item, englishStr];
-                }
+            if (/^(__GRAPHIE__|__IMAGE__|__WIDGET__)$/.test(normalObj.str)) {
+                return [item, englishStr];
             }
 
             if (suggestionGroups.hasOwnProperty(normalStr)) {
@@ -605,6 +623,16 @@ var TranslationAssistant = (function () {
                 if (template) {
                     var translatedStr = populateTemplate(template, englishStr, lang);
                     return [item, translatedStr];
+                }
+            }
+
+            // Translate items that are only math even if there's no template.
+            // TODO(kevinb) handle multiple non-nl_text items
+            if (normalObj.str === '__MATH__') {
+                // Only translate the math if it doesn't include any
+                // natural language text in \text and \textbf commands.
+                if (englishStr.indexOf('\\text') === -1) {
+                    return [item, translateMath(englishStr, lang)];
                 }
             }
 


### PR DESCRIPTION
JIRA: https://khanacademy.atlassian.net/browse/IC-662

Summary:
The current math translation system inside expects
that there is just one notation for a given operator for a given locale.
However, there might be different valid notations in some countries.
A typical example is \times and \cdot, the former is often used in lower
grades, but both are valid. We want to provide the translators the
flexibility to do both while still offering Smart Translations.

The proposed solution is a new function maybeTranslateMath(), which
decides which rules to apply by checking the template translations. I
went for the simplest heuristic I could think of. For example,
MAYBE_TIMES_AS_CDOT rule will be applied if:
1. Template translation contains \cdot at least once
anywhere in the translated text

AND

2. Template translation does not contain \times anywhere

It is unlikely that a single string would contain different notations.
If it does, we treat it as a translation mistake and ST will not be
offered.

Most importantly, this approach will allow us to handle cartesian
coordinates and intervals as well (will be done separately).
These are not possible to do atm because the US notation is the same for
both of these so we cannot determine how to translate them.

I was pleasantly surprised that the proposed change did not increase the
code complexity too much.

Obviously, this approach cannot work if the template is empty, which is
the case for strings containing only math. In this case, ST suggestions
will keep the US notation and translators will need to translate
manually if needed.

Also, we suppose that within a group, the math strings contain the same
notation, although that might not always be the case. I can imagine an
exercise that includes some problems with division and some with
multiplication, while keeping the NL text the same. In such a case, the
ST suggestions would depend on which of the string was translated as a
template. Also, this will be the case for math-only strings, where it's
quite likely to happen.
If we find this behaviour problematic, we'd need to modify the grouping
algorithm to create different groups based on used math notation.
I'd rather avoid that since it would add a lot of complexity
that I tried to avoid here. In any case, this change is a clear
improvement and should benefit translators as is.

Test Plan:
Test various locales and multiplication notations in exercise:
https://www.khanacademy.org/devadmin/content/exercises/factoring_linear_binomials/1126131850/x85f73fd8684daede

Closes #21 

(NOTE: I also implemented CDOT_AS_TIMES rule. I was assuming that US strings always use \times, but that's not the case. See #21