### PR TITLE
Translate notation for repeating decimals

### DIFF
--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -18,6 +18,11 @@ var MATH_RULES_LOCALES = {
    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka', 'ru'],
    ARABIC_COMMA: ['ps'],
    PERSO_ARABIC_NUMERALS: ['ps'],
+   // Notations for repeating decimals - 0.\overline{3}
+   // 0.(3)
+   OVERLINE_AS_DOT: ['bn'],
+   // 0.\dot{3}
+   OVERLINE_AS_PARENS: ['az', 'pt-pt'],
    // Binary operators
    // TODO(danielhollas):remove 'bg' from TIMES_AS_CDOT
    // when \mathbin{.} becomes available for them
@@ -108,6 +113,12 @@ function translateNumbers(math, lang) {
    { langs: MATH_RULES_LOCALES.ARABIC_COMMA,
       regex: decimalNumberRegex, replace: '$1{،}$2' },
 
+   // Different notations for repeating decimals
+   { langs: MATH_RULES_LOCALES.OVERLINE_AS_PARENS,
+      regex: /\\overline\{(\d+)\}/g, replace: '($1)' },
+
+   // MATH_RULES_LOCALES.OVERLINE_AS_DOT needs special handling
+
    // Thousand separator notations
 
    // No thousand separator
@@ -127,6 +138,18 @@ function translateNumbers(math, lang) {
          math = math.replace(element.regex, element.replace);
       }
    });
+
+   // Special handling for OVERLINE_AS_DOT rule for repeating decimals
+   // we need to translate 0.\overline{12} as 0.\dot{1}\dot{2}
+   if (MATH_RULES_LOCALES.OVERLINE_AS_DOT.includes(lang)) {
+      var fromRegex = new RegExp(/\\overline\{(\d+)\}/, 'g');
+      var match = undefined;
+      while ((match = fromRegex.exec(math)) !== null) {
+         var numbers = match[1];
+         var replace = numbers.replace(/\d/g, '\\dot{$&}');
+         math = math.replace(match[0], replace);
+      }
+   }
 
    return math;
 }

--- a/src/math-translator.js
+++ b/src/math-translator.js
@@ -19,6 +19,11 @@ const MATH_RULES_LOCALES = {
             'ru'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],
+    // Notations for repeating decimals - 0.\overline{3}
+    // 0.(3)
+    OVERLINE_AS_DOT: ['bn'],
+    // 0.\dot{3}
+    OVERLINE_AS_PARENS: ['az', 'pt-pt'],
     // Binary operators
     // TODO(danielhollas):remove 'bg' from TIMES_AS_CDOT
     // when \mathbin{.} becomes available for them
@@ -128,6 +133,12 @@ function translateNumbers(math, lang) {
          {langs: MATH_RULES_LOCALES.ARABIC_COMMA,
             regex: decimalNumberRegex, replace: '$1{،}$2'},
 
+         // Different notations for repeating decimals
+         {langs: MATH_RULES_LOCALES.OVERLINE_AS_PARENS,
+            regex: /\\overline\{(\d+)\}/g, replace: '($1)'},
+
+         // MATH_RULES_LOCALES.OVERLINE_AS_DOT needs special handling
+
          // Thousand separator notations
 
          // No thousand separator
@@ -148,6 +159,18 @@ function translateNumbers(math, lang) {
             math = math.replace(element.regex, element.replace);
         }
     });
+
+    // Special handling for OVERLINE_AS_DOT rule for repeating decimals
+    // we need to translate 0.\overline{12} as 0.\dot{1}\dot{2}
+    if (MATH_RULES_LOCALES.OVERLINE_AS_DOT.includes(lang)) {
+        const fromRegex = new RegExp(/\\overline\{(\d+)\}/, 'g');
+        let match;
+        while ((match = fromRegex.exec(math)) !== null) {
+            const numbers = match[1];
+            const replace = numbers.replace(/\d/g, '\\dot{$&}');
+            math = math.replace(match[0], replace);
+        }
+    }
 
     return math;
 }

--- a/tests/math_translator_spec.js
+++ b/tests/math_translator_spec.js
@@ -160,19 +160,41 @@ describe('MathTranslator (translateMath)', function() {
     });
 
     it('should translate repeating decimal numbers', function() {
+        // We cannot iterate over all locales from DECIMAL_COMMA
+        // because some of them have different notation for repeating decimals
+        // So we choose just one particular
+        const locale = 'cs';
+
         const englishStr = '1.\\overline{3} + 9.\\overline{44}';
         let translatedStr = '1{,}\\overline{3} + 9{,}\\overline{44}';
-
-        MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
-            const outputStr = translateMath(englishStr, locale);
-            assert.equal(outputStr, translatedStr);
-        });
+        const outputStr = translateMath(englishStr, locale);
+        assert.equal(outputStr, translatedStr);
 
         translatedStr = '۱{،}\\overline{۳} + ۹{،}\\overline{۴۴}';
         MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
             const outputStr = translateMath(englishStr, locale);
             assert.equal(outputStr, translatedStr);
         });
+    });
+
+    it('should translate \\overline in repeating decimals as \\dot',
+    function() {
+        // FROM MATH_RULES_LOCALES.OVERLINE_AS_DOT
+        const locale = 'bn';
+        const englishStr = '1.\\overline{3} + 9.\\overline{44}';
+        const translatedStr = '1.\\dot{3} + 9.\\dot{4}\\dot{4}';
+        const outputStr = translateMath(englishStr, locale);
+        assert.equal(outputStr, translatedStr);
+    });
+
+    it('should translate \\overline in repeating decimals as parentheses',
+    function() {
+        // FROM MATH_RULES_LOCALES.OVERLINE_AS_PARENS
+        const locale = 'pt-pt';
+        const englishStr = '1.\\overline{3} + 9.\\overline{44}';
+        const translatedStr = '1{,}(3) + 9{,}(44)';
+        const outputStr = translateMath(englishStr, locale);
+        assert.equal(outputStr, translatedStr);
     });
 
     it('should translate decimals wrapped in color commands', function() {


### PR DESCRIPTION
**Summary**

Repeating decimal is for example:
`1 / 3 = 0.\overline{3}`
but there are also other notations:
`1 / 3 = 0.\dot{3}`
or
`1 / 3 = 0.(3)`

See https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid=0

**Test Plan**
 1. Open exercise e/convert_fractions_to_decimals in European Portuguese
https://www.khanacademy.org/translations/edit/az/e/converting_fractions_to_decimals/tree/upstream/by-pattern
 2. Apply ST to pattern 8 strings containing repeating decimals
    \\overline should be replaced with parentheses
 3. Open the same exercise in bn
https://www.khanacademy.org/translations/edit/bn/e/converting_fractions_to_decimals/tree/upstream/by-pattern
 4. \overline should be translated as \dot