### PR TITLE
Translate intervals and coordinates

### DIFF
--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -287,7 +287,7 @@ function normalizeTranslatedMath(math, lang) {
 
     // Remove whitespace in coordinates/intervals
     // Applied to all langs because all langs can be affected by
-    // tranlatedCoordinates/translateIntervals/translateCoordinatesOrIntervals
+    // translatedCoordinates/translateIntervals/translateCoordinatesOrIntervals
     var orderedPair = getOrderedPairRegexString(lang);
     var coordsAndIntervals = new RegExp('([[⟨(\\]])' + orderedPair + '([[)⟩\\]])', 'g');
     math = math.replace(coordsAndIntervals, '$1$2$3$4$5');
@@ -378,6 +378,12 @@ var KATEX_BASE_COLORS = ['blue', 'gold', 'gray', 'mint', 'green', 'red', 'maroon
  *
  * We do not return the RegExp object, only the string
  * so that it can be combined into more complicated expressions.
+ *
+ * By default, the regex contains two capturing groups:
+ * 1. integer part
+ * 2. decimal part
+ * This can be changed by passing capture=false,
+ * this variant is used to construct regexes for coordinates and intervals.
  *
  * @param {string} lang The KA locale
  * @param {bool} capture whether to include capturing groups in regex
@@ -472,10 +478,14 @@ function getOrderedPairRegexString(lang) {
 }
 
 /**
- * Detect closed or half-closed intervals in US math expression.
+ * Detect closed or half-closed intervals in US math expression, such as
+ * '[a,b]', '[1,2)' or '(0,5]'
+ *
+ * (the expression can contain numbers or single-letter variables,
+ * see getOrderedpairRegexString)
  *
  * We cannot detect open intervals, because they have the same
- * notation as cartesian coordinates in the US
+ * notation as cartesian coordinates in the US.
  *
  * @param {string} math English math string
  * @returns {bool} true if math contains at least one interval
@@ -588,6 +598,7 @@ function translateCoordinates(math, template, lang) {
 
 /**
  * Translate notation for intervals (opened, closed, half-closed)
+ * e.g. '(-1,1)', '(0, a]' or '[\blue3,\red4]'
  *
  * @param {string} math A math expression to be translated
  * @param {string} template User-translated template
@@ -652,9 +663,13 @@ function translateIntervals(math, template, lang) {
 
 /**
  * Translate notation of coordinates or open intervals.
+ *
  * Since the US notation is the same, we cannot really distinguish
  * the two apart. So we will detect the notation from the user-translated
  * template and use it. Without the template, we return the same string.
+ *
+ * Example US strings:
+ * '(0,1)', '(a,b)', '(1.4, \red{5.6})'
  *
  * @param {string} math A math expression to be translated
  * @param {string} template User-translated template

--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -42,10 +42,10 @@ var MATH_RULES_LOCALES = {
     DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'pl', 'it', 'pt-pt', 'ru', 'nb'],
     // Trig functions
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
-    TAN_AS_TG: ['az', 'bg', 'hu', 'hy', 'pt', 'pt-pt'],
-    COT_AS_COTG: ['pt', 'pt-pt'],
+    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'pt', 'pt-pt'],
+    COT_AS_COTG: ['cs', 'pt', 'pt-pt'],
     COT_AS_CTG: ['az', 'hu', 'hy', 'bg'],
-    CSC_AS_COSEC: ['az', 'bg', 'bn'],
+    CSC_AS_COSEC: ['az', 'bg', 'bn', 'cs'],
     CSC_AS_COSSEC: ['pt', 'pt-pt'],
     // Rules conditional on the translated template
     MAYBE_DIV_AS_COLON: ['id', 'lol'],
@@ -605,11 +605,15 @@ function translateIntervals(math, template, lang) {
         regex: leftClosedInterval, replace: '[$1' + sep + '$3[' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
         regex: rightClosedInterval, replace: ']$1' + sep + '$3]' },
     // closed intervals with angle brackets
+    // We cannot use \langle|\rangle because of the linter
+    // so we insert equivalent unicode chars directly.
+    // U+27E8 | ⟨ | \xe2\x9f\xa8 | MATHEMATICAL LEFT ANGLE BRACKET
+    // U+27E9 | ⟩ | \xe2\x9f\xa9 | MATHEMATICAL RIGHT ANGLE BRACKET
     { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
         regex: openInterval, replace: '($1' + sep + '$3)' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-        regex: closedInterval, replace: '<$1' + sep + '$3>' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-        regex: leftClosedInterval, replace: '<$1' + sep + '$3)' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-        regex: rightClosedInterval, replace: '($1' + sep + '$3>' }];
+        regex: closedInterval, replace: '⟨$1' + sep + '$3⟩' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+        regex: leftClosedInterval, replace: '⟨$1' + sep + '$3)' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+        regex: rightClosedInterval, replace: '($1' + sep + '$3⟩' }];
 
     intervalTranslations.forEach(function (el) {
         if (el.langs.includes(lang)) {

--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -1,6 +1,6 @@
 /**
  * This file contains functions for translating math notation
- * as well as a list of locales that these functions should be applied to
+ * as well as a list of locales that these functions should be applied to.
  */
 
 /**
@@ -14,19 +14,30 @@ var MATH_RULES_LOCALES = {
     // Number formats
     THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
     THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el', 'id'],
-    NO_THOUSAND_SEP: ['ko', 'ps', 'ka'],
-    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka', 'ru', 'ta'],
+    NO_THOUSAND_SEP: ['ko', 'ps', 'ka', 'hy'],
+    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka', 'ru', 'ta', 'hy'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],
     // Notations for repeating decimals - 0.\overline{3}
-    // 0.(3)
-    OVERLINE_AS_DOT: ['bn'],
     // 0.\dot{3}
-    OVERLINE_AS_PARENS: ['az', 'pt-pt'],
+    OVERLINE_AS_DOT: ['bn'],
+    // 0.(3)
+    OVERLINE_AS_PARENS: ['az', 'pt-pt', 'hy', 'pl'],
+
+    // Intervals and cartesian coordinates
+    // (a,b) - US open interval or coordinates
+    // [a,b] - US closed interval
+    // [a,b), (a, b] - US half open interval
+    //
+    // Inverted brackets notation for open intervals
+    // (a,b) -> ]a,b[
+    OPEN_INT_AS_BRACKETS: ['da', 'fr', 'hu', 'pt-pt'],
+    CLOSED_INT_AS_ANGLE_BRACKETS: ['cs'],
+    COORDS_AS_BRACKETS: ['cs'],
     // Binary operators
     // TODO(danielhollas):remove 'bg' from TIMES_AS_CDOT
     // when \mathbin{.} becomes available for them
-    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da', 'bg'],
+    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'hy', 'sv', 'da', 'bg'],
     CDOT_AS_TIMES: ['fr', 'ps', 'pt-pt', 'ta'],
     DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'pl', 'it', 'pt-pt', 'ru', 'nb'],
     // Trig functions
@@ -38,9 +49,35 @@ var MATH_RULES_LOCALES = {
     CSC_AS_COSSEC: ['pt', 'pt-pt'],
     // Rules conditional on the translated template
     MAYBE_DIV_AS_COLON: ['id', 'lol'],
-    MAYBE_TIMES_AS_CDOT: ['az', 'bn', 'el', 'hi', 'hy', 'id', 'it', 'ja', 'ka', 'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
-    MAYBE_CDOT_AS_TIMES: ['az', 'bn', 'el', 'hi', 'hy', 'id', 'it', 'ja', 'ka', 'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol']
+    MAYBE_TIMES_AS_CDOT: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka', 'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
+    MAYBE_CDOT_AS_TIMES: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka', 'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol']
 };
+
+/**
+ * Translates math notation in English strings to match
+ * notation for a given language, such as thousand separators,
+ * decimal commas, math operators etc.
+ *
+ * This function serves as an interface to all the other functions
+ * in this file.
+ *
+ * @param {string} math math expression to translate
+ * @param {string} template User-translated template
+ * @param {string} lang KA locale of the translation language.
+ * @returns {string} translated math expression.
+ */
+function translateMath(math, template, lang) {
+
+    // Need to call this one first, because the regexes
+    // rely on US number formats
+    math = maybeTranslateMath(math, template, lang);
+
+    math = translateMathOperators(math, lang);
+    math = translateNumbers(math, lang);
+    // This one needs to be last
+    math = translateNumerals(math, lang);
+    return math;
+}
 
 /**
  * Translates western-arabic numerals to others, see:
@@ -77,28 +114,10 @@ function translateNumbers(math, lang) {
 
     // These consts are used only here for manipulating thousand separator
     var placeholder = 'THSEP';
-    var USThousandSeparatorRegex = new RegExp('([0-9])' + placeholder + '([0-9])(?=[0-9]{2})', 'g');
+    var thousandSeparatorRegex = new RegExp('([0-9])' + placeholder + '([0-9])(?=[0-9]{2})', 'g');
     var thousandSeparatorLocales = [].concat(MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE, MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT, MATH_RULES_LOCALES.NO_THOUSAND_SEP);
 
-    // Definition of regex for decimal numbers
-    // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
-    // repeating decimals like '1/3 = 0.\\overline{3}'
-    //
-    // Colors currently used in KA strings taken from KaTeX definitions, see:
-    // https://github.com/KaTeX/KaTeX/blob/master/src/macros.js
-    //
-    // \\overline is handled elsewhere since it appears only
-    // on the right side of the decimal point
-    //
-    // These colors are appended by optional [A-Z]? to match all definitions
-    // from KaTeX. This will form a superset of actually defined colors,
-    // but that hardly matters here and is more future-proof if new colors
-    // were defined at some point
-    var katexColorMacros = ['blue', 'gold', 'gray', 'mint', 'green', 'red', 'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen'].join('|');
-
-    var integerPart = '[0-9]+|\\\\(?:' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
-    var decPart = '[0-9]+|\\\\(?:overline|' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
-    var decimalNumberRegex = new RegExp('(' + integerPart + ')\\.(' + decPart + ')', 'g');
+    var decimalNumberRegex = new RegExp(getDecNumberRegexString('en'), 'g');
 
     var mathTranslations = [
     // IMPORTANT NOTE: This MUST be the first regex
@@ -128,15 +147,15 @@ function translateNumbers(math, lang) {
 
     // No thousand separator
     { langs: MATH_RULES_LOCALES.NO_THOUSAND_SEP,
-        regex: USThousandSeparatorRegex, replace: '$1$2' },
+        regex: thousandSeparatorRegex, replace: '$1$2' },
 
     // Thousand separator as a dot
     { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
-        regex: USThousandSeparatorRegex, replace: '$1.$2' },
+        regex: thousandSeparatorRegex, replace: '$1.$2' },
 
     // Thousand separator as a thin space (\, in Tex)
     { langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
-        regex: USThousandSeparatorRegex, replace: '$1\\,$2' }];
+        regex: thousandSeparatorRegex, replace: '$1\\,$2' }];
 
     mathTranslations.forEach(function (element) {
         if (element.langs.includes(lang)) {
@@ -207,22 +226,6 @@ function translateMathOperators(math, lang) {
         }
     });
 
-    return math;
-}
-
-/**
- * Handles any per language special case translations
- * e.g. thousand separators, decimal commas, math operators etc.
- *
- * @param {string} math A math expression to translate
- * @param {string} lang The KA locale of the translation language.
- * @returns {string} The translated math expression.
- */
-function translateMath(math, lang) {
-    // The order here should not matter
-    math = translateMathOperators(math, lang);
-    math = translateNumbers(math, lang);
-    math = translateNumerals(math, lang);
     return math;
 }
 
@@ -304,6 +307,25 @@ function normalizeTranslatedMath(math, lang) {
  * @returns {string} translated math expression.
  */
 function maybeTranslateMath(math, template, lang) {
+
+    // A heuristic for intervals and coordinates:
+    // We assume that a single string will not mix intervals and coordinates
+    // 1. Try to find closed/half-closed intervals
+    // 2. If not found, try to detect coordinates
+    // (for details, see comment for detectCoordinates())
+    // 3. For certain strings such as (1,2), we cannot differentiate
+    // between coordinates and intervals so we will extract the notation
+    // from the translated template.
+    if (detectClosedInterval(math)) {
+        math = translateIntervals(math, template, lang);
+    } else if (detectCoordinates(math)) {
+        math = translateCoordinates(math, template, lang);
+    } else {
+        math = translateCoordinatesOrOpenIntervals(math, template, lang);
+    }
+
+    // The rest of the rules can be applied only
+    // when we have the translated template.
     if (!template) {
         return math;
     }
@@ -329,9 +351,346 @@ function maybeTranslateMath(math, template, lang) {
     return math;
 }
 
+/**
+ * Base colors currently used in KA strings taken from KaTeX definitions, see:
+ * https://github.com/KaTeX/KaTeX/blob/master/src/macros.js
+ * There can be different variants of a single color, such as \redA or \blueD,
+ * but that's handled elsewhere.
+ */
+var KATEX_BASE_COLORS = ['blue', 'gold', 'gray', 'mint', 'green', 'red', 'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen'];
+
+/**
+ * Construct regular expression to match decimal numbers for a given lang,
+ * possibly wrapped in TeX commands.
+ *
+ * We do not return the RegExp object, only the string
+ * so that it can be combined into more complicated expressions.
+ *
+ * @param {string} lang The KA locale
+ * @param {bool} capture whether to include capturing groups in regex
+ * @returns {string} String to be passed into RegExp constructor.
+ */
+function getDecNumberRegexString(lang) {
+    var capture = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
+
+    // Definition of regex for decimal numbers
+    // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
+    // repeating decimals like '1/3 = 0.\\overline{3}'
+    //
+    // These colors are appended by optional [A-Z]? to match all definitions
+    // from KaTeX. This will form a superset of actually defined colors,
+    // but that hardly matters here and is more future-proof if new colors
+    // were defined at some point
+    var katexColorMacros = KATEX_BASE_COLORS.join('|');
+
+    var integerPart = '[0-9]+|\\\\(?:' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
+    // Decimal part is different from integer part
+    // because it can contain \\overline
+    // TODO: Some langs do not use \\overline, but \\dot
+    var decPart = '[0-9]+|\\\\(?:overline|' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
+
+    var sep = getEscapedDecimalSeparator(lang);
+
+    // This part matches strings like `\\green{1.2}`
+    var wrappedDecimal = '\\\\(?:' + katexColorMacros + ')[A-Z]?\\{-?[0-9]+' + sep + '[0-9]+\\}';
+
+    // Wrapped decimal is not needed if we capture integer and decimal part
+    // because in that case we do not care that the decimal number
+    // is wrapped as a whole
+    return capture ? '(' + integerPart + ')' + sep + '(' + decPart + ')' : '(?:(?:' + integerPart + ')' + sep + '(?:' + decPart + '))|(?:' + wrappedDecimal + ')';
+}
+
+/**
+ * Return decimal separator for a given language.
+ * The separator is used in regex so it needs to be escaped.
+ *
+ * @param {string} lang KA locale
+ * @returns {string} Decimal separator to be passed into RegExp constructor.
+ */
+function getEscapedDecimalSeparator(lang) {
+    if (MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang)) {
+        return '\\{,\\}';
+    } else if (MATH_RULES_LOCALES.ARABIC_COMMA.includes(lang)) {
+        return '\\{،\\}';
+    } else {
+        return '\\.';
+    }
+}
+
+/**
+ * Build regex string for ranges (inside intervals)
+ * or, equivalently, cartesian coordinates (without parentheses).
+ *
+ * Matches strings such as:
+ * '-1,0'
+ * '1.2;3'
+ * '\greenD4, \blue{1{,}2}'
+ * 'x,y'
+ *
+ * We pass in the language param, because we need to match
+ * different notations for decimal numbers
+ *
+ * @param {string} lang KA locale
+ * @returns {string} string to be passed to RegExp constructor
+ */
+function getRangeRegexString(lang) {
+    var katexColorMacros = '\\\\(?:' + KATEX_BASE_COLORS.join('|') + ')[A-Z]?';
+    // Assuming single-letter variables and numbers below 1000
+    // (without thousand separator)
+    var integer = '-?[0-9]+|-?' + katexColorMacros + '\\{-?[0-9]+\\}|-?' + katexColorMacros + '[0-9]';
+    var variable = '[a-z]|' + katexColorMacros + '\\{[a-z]\\}';
+    var decimal = getDecNumberRegexString(lang,
+    /* don't include capture groups */false);
+    var numberOrLetter = variable + '|' + decimal + '|' + integer;
+    // NOTE(danielhollas): We allow comma and semicolon for all langs
+    // as separators, even though maybe some langs use only comma.
+    // Since the US strings always have commas (I think),
+    // it's not a big deal if we are more permissive.
+    // If a translator bothered to change it to semicolon,
+    // they probably had a reason.
+    var separators = ',;';
+    if (lang === 'de') {
+        separators += '|'; // For German coordinates
+    }
+    // Support LaTeX spaces, e.g. '4~; 3' (used in e.g. French notation)
+    var space = '(?:\\\\,|~|\\s)*';
+    var sep = space + '[' + separators + ']' + space;
+    return '\\s*(' + numberOrLetter + ')(' + sep + ')(' + numberOrLetter + ')\\s*';
+}
+
+/**
+ * Detect closed or half-closed intervals in US math expression.
+ *
+ * We cannot detect open intervals, because they have the same
+ * notation as cartesian coordinates in the US
+ *
+ * @param {string} math English math string
+ * @returns {bool} true if math contains at least one interval
+ */
+function detectClosedInterval(math) {
+    var lang = 'en';
+    var interval = getRangeRegexString(lang);
+    var closedInterval = '\\[' + interval + '\\]';
+    var leftClosedInterval = '\\[' + interval + '\\)';
+    var rightClosedInterval = '\\(' + interval + '\\]';
+    return math.match(closedInterval) || math.match(leftClosedInterval) || math.match(rightClosedInterval);
+}
+
+/**
+ * A heuristic for detecting cartesian coordinates in US math expressions.
+ *
+ * Given `(a,b)`, an interval would always have a < b
+ * (4, 2) is a coordinate
+ * (2, 4) may be coordinate or open interval so we return false
+ * (x, y) can also be coordinate or open interval so we return false
+ *
+ * @param {string} math English math string
+ * @returns {bool} true if math definitely contains cartesian coordinates
+ */
+function detectCoordinates(math) {
+    var lang = 'en';
+    var coords = getRangeRegexString(lang);
+    var coordsRegex = new RegExp('\\(' + coords + '\\)', 'g');
+    var match = undefined;
+    while ((match = coordsRegex.exec(math)) !== null && match.length === 4) {
+        // Remove color commands around numbers
+        var num1 = match[1].replace(/[a-zA-Z]|\{|\}|\\/g, '');
+        var num2 = match[3].replace(/[a-zA-Z]|\{|\}|\\/g, '');
+        var a = parseFloat(num1);
+        var b = parseFloat(num2);
+        if (a >= b) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Extract the separator from a translated template.
+ * If empty, the default separator is used.
+ *
+ * Regular expression is passed in that matches coordinates/intervals
+ * in a given language. The separator is captured in the second group.
+ *
+ * @param {string} template User-translated template (optional)
+ * @param {string} regex Regular expression matching coordinates/intervals
+ * @param {string} lang KA locale of the translation language.
+ * @returns {string} Translated string
+ */
+function getSeparator(template, regex, lang) {
+    var sepDefault = ',';
+    // Languages with decimal comma typically use semicolon
+    if (MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang)) {
+        sepDefault = ';';
+    }
+    var match = undefined;
+    // Return separator from the template if detected
+    if (template && (match = template.match(regex)) !== null && match.length === 4) {
+        return match[2];
+    } else {
+        return sepDefault;
+    }
+}
+
+/**
+ * Translates notation for cartesian coordinates, such as:
+ * (3,0) or (x,y)
+ *
+ * A translated template is used to determine the separator.
+ * If empty, the default separator is used.
+ *
+ * @param {string} math A math expression to be translated
+ * @param {string} template User-translated template (optional)
+ * @param {string} lang The KA locale of the translation language.
+ * @returns {string} Translated string
+ */
+function translateCoordinates(math, template, lang) {
+    var coordsUS = getRangeRegexString('en');
+    var coordsRegexUS = new RegExp('\\(' + coordsUS + '\\)', 'g');
+
+    var coords = getRangeRegexString(lang);
+    var coordsRegex = undefined;
+    if (MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang)) {
+        coordsRegex = new RegExp('\\[' + coords + '\\]');
+    } else {
+        coordsRegex = new RegExp('\\(' + coords + '\\)');
+    }
+
+    var sep = getSeparator(template, coordsRegex, lang);
+
+    var coordsTranslations = [{ langs: MATH_RULES_LOCALES.COORDS_AS_BRACKETS,
+        regex: coordsRegexUS, replace: '[$1' + sep + '$3]' }];
+
+    coordsTranslations.forEach(function (el) {
+        if (el.langs.includes(lang)) {
+            math = math.replace(el.regex, el.replace);
+        } else {
+            // For all other langs translate only the separator
+            math = math.replace(el.regex, '($1' + sep + '$3)');
+        }
+    });
+
+    return math;
+}
+
+/**
+ * Translate notation for intervals (opened, closed, half-closed)
+ *
+ * @param {string} math A math expression to be translated
+ * @param {string} template User-translated template
+ * @param {string} lang The KA locale of the translation language.
+ * @returns {string} Translated string
+ */
+function translateIntervals(math, template, lang) {
+    var intervalUS = getRangeRegexString('en');
+    var closedInterval = new RegExp('\\[' + intervalUS + '\\]', 'g');
+    var openInterval = new RegExp('\\(' + intervalUS + '\\)', 'g');
+    var leftClosedInterval = new RegExp('\\[' + intervalUS + '\\)', 'g');
+    var rightClosedInterval = new RegExp('\\(' + intervalUS + '\\]', 'g');
+
+    // Detect range separator in the template, can be comma or semicolon
+    // We expect that if template contains more intervals, they will have
+    // the same separator. The can also include any whitespace chars.
+    // Again, these need to be consistent in all intervals!
+    var interval = getRangeRegexString(lang);
+    var generalInterval = new RegExp('[[(\\]]' + interval + '[[)\\]]');
+
+    var sep = getSeparator(template, generalInterval, lang);
+
+    var intervalTranslations = [
+    // open intervals with inverted brackets
+    { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+        regex: openInterval, replace: ']$1' + sep + '$3[' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+        regex: closedInterval, replace: '[$1' + sep + '$3]' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+        regex: leftClosedInterval, replace: '[$1' + sep + '$3[' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+        regex: rightClosedInterval, replace: ']$1' + sep + '$3]' }];
+
+    intervalTranslations.forEach(function (el) {
+        if (el.langs.includes(lang)) {
+            math = math.replace(el.regex, el.replace);
+        }
+    });
+
+    // For all other languages not listed above,
+    // translated only the separator
+    if (MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang)) {
+        return math;
+    }
+
+    // The only thing we translate here is the separator!
+    var separatorTranslations = [{ regex: openInterval, replace: '($1' + sep + '$3)' }, { regex: closedInterval, replace: '[$1' + sep + '$3]' }, { regex: leftClosedInterval, replace: '[$1' + sep + '$3)' }, { regex: rightClosedInterval, replace: '($1' + sep + '$3]' }];
+
+    separatorTranslations.forEach(function (el) {
+        math = math.replace(el.regex, el.replace);
+    });
+
+    return math;
+}
+
+/**
+ * Translate notation of coordinates or open intervals.
+ * Since the US notation is the same, we cannot really distinguish
+ * the two apart. So we will detect the notation from the user-translated
+ * template and use it. Without the template, we return the same string.
+ *
+ * @param {string} math A math expression to be translated
+ * @param {string} template User-translated template
+ * @param {string} lang Khan language
+ * @returns {string} translated string
+ */
+function translateCoordinatesOrOpenIntervals(math, template, lang) {
+    if (!template) {
+        return math;
+    }
+    var rangeUS = getRangeRegexString('en');
+    var coordsOrOpenIntervalUS = new RegExp('\\(' + rangeUS + '\\)', 'g');
+
+    // First look into the English string
+    var match = math.match(coordsOrOpenIntervalUS);
+    if (!match) {
+        return math;
+    }
+    // Now we know that the English string contains coordinates or intervals
+    // Let's detect them in the template, if we fail,
+    // we return prematurely
+    var range = getRangeRegexString(lang);
+    var coordsOrOpenInterval = new RegExp('([[(\\]])' + range + '([[)\\]])');
+    match = template.match(coordsOrOpenInterval);
+    if (!match || match.length !== 6) {
+        return math;
+    }
+
+    var left = match[1];
+    var sep = match[3];
+    var right = match[5];
+
+    // Verify that left and right parentheses|brackets make sense
+    // for a given language
+    switch (left) {
+        case '[':
+            if (right !== ']' || !MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang)) return math;
+            break;
+        case ']':
+            if (right !== '[' || !MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang)) return math;
+            break;
+        case '(':
+            if (right !== ')') return math;
+            break;
+        default:
+            return math;
+    }
+
+    var replace = left + '$1' + sep + '$3' + right;
+
+    return math.replace(coordsOrOpenIntervalUS, replace);
+}
+
 module.exports = {
     translateMath: translateMath,
+    // The following are exported only for testing
     maybeTranslateMath: maybeTranslateMath,
     normalizeTranslatedMath: normalizeTranslatedMath,
-    MATH_RULES_LOCALES: MATH_RULES_LOCALES
+    MATH_RULES_LOCALES: MATH_RULES_LOCALES,
+    detectClosedInterval: detectClosedInterval,
+    detectCoordinates: detectCoordinates
 };

--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -68,6 +68,10 @@ var MATH_RULES_LOCALES = {
  */
 function translateMath(math, template, lang) {
 
+    if (lang === 'en') {
+        return math;
+    }
+
     // Need to call this one first, because the regexes
     // rely on US number formats
     math = maybeTranslateMath(math, template, lang);
@@ -242,6 +246,8 @@ function translateMathOperators(math, lang) {
  */
 function normalizeTranslatedMath(math, lang) {
 
+    if (lang === 'en') return math;
+
     var mathNormalizations = [
     // Strip superfluous curly braces around \\,
     // which is used as thousand separator in some locales
@@ -278,6 +284,13 @@ function normalizeTranslatedMath(math, lang) {
             math = math.replace(element.regex, element.replace);
         }
     });
+
+    // Remove whitespace in coordinates/intervals
+    // Applied to all langs because all langs can be affected by
+    // tranlatedCoordinates/translateIntervals/translateCoordinatesOrIntervals
+    var orderedPair = getOrderedPairRegexString(lang);
+    var coordsAndIntervals = new RegExp('([[⟨(\\]])' + orderedPair + '([[)⟩\\]])', 'g');
+    math = math.replace(coordsAndIntervals, '$1$2$3$4$5');
 
     return math;
 }
@@ -433,7 +446,7 @@ function getEscapedDecimalSeparator(lang) {
  * @param {string} lang KA locale
  * @returns {string} string to be passed to RegExp constructor
  */
-function getRangeRegexString(lang) {
+function getOrderedPairRegexString(lang) {
     var katexColorMacros = '\\\\(?:' + KATEX_BASE_COLORS.join('|') + ')[A-Z]?';
     // Assuming single-letter variables and numbers below 1000
     // (without thousand separator)
@@ -469,7 +482,7 @@ function getRangeRegexString(lang) {
  */
 function detectClosedInterval(math) {
     var lang = 'en';
-    var interval = getRangeRegexString(lang);
+    var interval = getOrderedPairRegexString(lang);
     var closedInterval = '\\[' + interval + '\\]';
     var leftClosedInterval = '\\[' + interval + '\\)';
     var rightClosedInterval = '\\(' + interval + '\\]';
@@ -489,7 +502,7 @@ function detectClosedInterval(math) {
  */
 function detectCoordinates(math) {
     var lang = 'en';
-    var coords = getRangeRegexString(lang);
+    var coords = getOrderedPairRegexString(lang);
     var coordsRegex = new RegExp('\\(' + coords + '\\)', 'g');
     var match = undefined;
     while ((match = coordsRegex.exec(math)) !== null && match.length === 4) {
@@ -545,10 +558,10 @@ function getSeparator(template, regex, lang) {
  * @returns {string} Translated string
  */
 function translateCoordinates(math, template, lang) {
-    var coordsUS = getRangeRegexString('en');
+    var coordsUS = getOrderedPairRegexString('en');
     var coordsRegexUS = new RegExp('\\(' + coordsUS + '\\)', 'g');
 
-    var coords = getRangeRegexString(lang);
+    var coords = getOrderedPairRegexString(lang);
     var coordsRegex = undefined;
     if (MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang)) {
         coordsRegex = new RegExp('\\[' + coords + '\\]');
@@ -582,7 +595,7 @@ function translateCoordinates(math, template, lang) {
  * @returns {string} Translated string
  */
 function translateIntervals(math, template, lang) {
-    var intervalUS = getRangeRegexString('en');
+    var intervalUS = getOrderedPairRegexString('en');
     var closedInterval = new RegExp('\\[' + intervalUS + '\\]', 'g');
     var openInterval = new RegExp('\\(' + intervalUS + '\\)', 'g');
     var leftClosedInterval = new RegExp('\\[' + intervalUS + '\\)', 'g');
@@ -592,7 +605,7 @@ function translateIntervals(math, template, lang) {
     // We expect that if template contains more intervals, they will have
     // the same separator. The can also include any whitespace chars.
     // Again, these need to be consistent in all intervals!
-    var interval = getRangeRegexString(lang);
+    var interval = getOrderedPairRegexString(lang);
     var generalInterval = new RegExp('[[(\\]]' + interval + '[[)\\]]');
 
     var sep = getSeparator(template, generalInterval, lang);
@@ -652,8 +665,8 @@ function translateCoordinatesOrOpenIntervals(math, template, lang) {
     if (!template) {
         return math;
     }
-    var rangeUS = getRangeRegexString('en');
-    var coordsOrOpenIntervalUS = new RegExp('\\(' + rangeUS + '\\)', 'g');
+    var orderedPairUS = getOrderedPairRegexString('en');
+    var coordsOrOpenIntervalUS = new RegExp('\\(' + orderedPairUS + '\\)', 'g');
 
     // First look into the English string
     var match = math.match(coordsOrOpenIntervalUS);
@@ -663,8 +676,8 @@ function translateCoordinatesOrOpenIntervals(math, template, lang) {
     // Now we know that the English string contains coordinates or intervals
     // Let's detect them in the template, if we fail,
     // we return prematurely
-    var range = getRangeRegexString(lang);
-    var coordsOrOpenInterval = new RegExp('([[(\\]])' + range + '([[)\\]])');
+    var orderedPair = getOrderedPairRegexString(lang);
+    var coordsOrOpenInterval = new RegExp('([[(\\]])' + orderedPair + '([[)\\]])');
     match = template.match(coordsOrOpenInterval);
     if (!match || match.length !== 6) {
         return math;

--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -603,7 +603,13 @@ function translateIntervals(math, template, lang) {
         regex: openInterval, replace: ']$1' + sep + '$3[' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
         regex: closedInterval, replace: '[$1' + sep + '$3]' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
         regex: leftClosedInterval, replace: '[$1' + sep + '$3[' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
-        regex: rightClosedInterval, replace: ']$1' + sep + '$3]' }];
+        regex: rightClosedInterval, replace: ']$1' + sep + '$3]' },
+    // closed intervals with angle brackets
+    { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+        regex: openInterval, replace: '($1' + sep + '$3)' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+        regex: closedInterval, replace: '<$1' + sep + '$3>' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+        regex: leftClosedInterval, replace: '<$1' + sep + '$3)' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+        regex: rightClosedInterval, replace: '($1' + sep + '$3>' }];
 
     intervalTranslations.forEach(function (el) {
         if (el.langs.includes(lang)) {
@@ -612,8 +618,8 @@ function translateIntervals(math, template, lang) {
     });
 
     // For all other languages not listed above,
-    // translated only the separator
-    if (MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang)) {
+    // translate only the separator
+    if (MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang) || MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS.includes(lang)) {
         return math;
     }
 

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -477,6 +477,8 @@ function populateTemplate(template, englishStr, lang) {
         try {
             englishMapping = getMapping(englishStr, englishStr, 'en', MATH_REGEX, englishDictionary);
         } catch (error) {
+            console.error( // eslint-disable-line no-console
+            'Unexpected error in TranslationAssistant.populateTemplate');
             return undefined;
         }
         // And verify that the math mapping is identical to the one in the

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -10,7 +10,6 @@ var _require = require('./math-translator');
 
 var translateMath = _require.translateMath;
 var normalizeTranslatedMath = _require.normalizeTranslatedMath;
-var maybeTranslateMath = _require.maybeTranslateMath;
 
 // Matches math delimited by $, e.g.
 // $x^2 + 2x + 1 = 0$
@@ -139,9 +138,7 @@ mathDictionary) {
             // from the entire template
             var allTranslatedMaths = outputs.join(' ');
             inputs = inputs.map(function (input) {
-                return maybeTranslateMath(input, allTranslatedMaths, lang);
-            }).map(function (input) {
-                return translateMath(input, lang);
+                return translateMath(input, allTranslatedMaths, lang);
             }).map(function (input) {
                 return replaceTextInMath(input, mathDictionary);
             });
@@ -232,17 +229,14 @@ function getMathDictionary(englishStr, translatedStr, lang) {
     // Used in maybeTranslateMath() to pattern-match the translated math
     // from the entire template
     var allTranslatedMaths = outputs.join(' ');
+    inputs = inputs.map(function (input) {
+        return translateMath(input, allTranslatedMaths, lang);
+    });
 
     var inputMap = {};
     var outputMap = {};
 
     var replaceRegexes = [[TEXT_REGEX, '__TEXT__'], [TEXTBF_REGEX, '__TEXTBF__']];
-
-    inputs = inputs.map(function (input) {
-        return maybeTranslateMath(input, allTranslatedMaths, lang);
-    }).map(function (input) {
-        return translateMath(input, lang);
-    });
 
     inputs.forEach(function (input) {
         var normalized = input;
@@ -494,8 +488,8 @@ function populateTemplate(template, englishStr, lang) {
     var images = englishStr.match(IMAGE_REGEX) || [];
     var widgets = englishStr.match(WIDGET_REGEX) || [];
 
-    // Used in maybeTranslateMath() to pattern-match the translated math
-    // from the entire template
+    // Used in maybeTranslateMath() (called in translateMath)
+    // to pattern-match the translated math from the entire template
     var allTranslatedMaths = template.translatedMaths.join(' ');
 
     var mathIndex = 0;
@@ -504,9 +498,7 @@ function populateTemplate(template, englishStr, lang) {
     var widgetIndex = 0;
 
     maths = maths.map(function (math) {
-        return maybeTranslateMath(math, allTranslatedMaths, lang);
-    }).map(function (math) {
-        return translateMath(math, lang);
+        return translateMath(math, allTranslatedMaths, lang);
     }).map(function (math) {
         return replaceTextInMath(math, template.mathDictionary);
     });
@@ -632,7 +624,7 @@ var TranslationAssistant = (function () {
                 // Only translate the math if it doesn't include any
                 // natural language text in \text and \textbf commands.
                 if (englishStr.indexOf('\\text') === -1) {
-                    return [item, translateMath(englishStr, lang)];
+                    return [item, translateMath(englishStr, '', lang)];
                 }
             }
 

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -468,7 +468,17 @@ function populateTemplate(template, englishStr, lang) {
         // To that end we create an English to English math mapping for this
         // string.
         var englishDictionary = getMathDictionary(englishStr, englishStr, lang);
-        var englishMapping = getMapping(englishStr, englishStr, 'en', MATH_REGEX, englishDictionary);
+
+        var englishMapping = undefined;
+
+        // This call to getMapping() should be safe because we're
+        // comparing English string with itself. Nevertheless, we're cautious
+        // so we don't crash the Translation Editor.
+        try {
+            englishMapping = getMapping(englishStr, englishStr, 'en', MATH_REGEX, englishDictionary);
+        } catch (error) {
+            return undefined;
+        }
         // And verify that the math mapping is identical to the one in the
         // template.
         if (JSON.stringify(englishMapping) !== JSON.stringify(template.mathMapping.englishToEnglish)) {

--- a/src/math-translator.js
+++ b/src/math-translator.js
@@ -660,6 +660,15 @@ function translateIntervals(math, template, lang) {
             regex: leftClosedInterval, replace: `[$1${sep}$3[`},
         {langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
             regex: rightClosedInterval, replace: `]$1${sep}$3]`},
+        // closed intervals with angle brackets
+        {langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+            regex: openInterval, replace: `($1${sep}$3)`},
+        {langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+            regex: closedInterval, replace: `<$1${sep}$3>`},
+        {langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+            regex: leftClosedInterval, replace: `<$1${sep}$3)`},
+        {langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+            regex: rightClosedInterval, replace: `($1${sep}$3>`},
     ];
 
     intervalTranslations.forEach(function(el) {
@@ -669,8 +678,9 @@ function translateIntervals(math, template, lang) {
     });
 
     // For all other languages not listed above,
-    // translated only the separator
-    if (MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang)) {
+    // translate only the separator
+    if (MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang) ||
+        MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS.includes(lang) ) {
         return math;
     }
 

--- a/src/math-translator.js
+++ b/src/math-translator.js
@@ -45,10 +45,10 @@ const MATH_RULES_LOCALES = {
             'pt-pt', 'ru', 'nb'],
     // Trig functions
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
-    TAN_AS_TG: ['az', 'bg', 'hu', 'hy', 'pt', 'pt-pt'],
-    COT_AS_COTG: ['pt', 'pt-pt'],
+    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'pt', 'pt-pt'],
+    COT_AS_COTG: ['cs', 'pt', 'pt-pt'],
     COT_AS_CTG: ['az', 'hu', 'hy', 'bg'],
-    CSC_AS_COSEC: ['az', 'bg', 'bn'],
+    CSC_AS_COSEC: ['az', 'bg', 'bn', 'cs'],
     CSC_AS_COSSEC: ['pt', 'pt-pt'],
     // Rules conditional on the translated template
     MAYBE_DIV_AS_COLON: ['id', 'lol'],
@@ -661,14 +661,18 @@ function translateIntervals(math, template, lang) {
         {langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
             regex: rightClosedInterval, replace: `]$1${sep}$3]`},
         // closed intervals with angle brackets
+        // We cannot use \langle|\rangle because of the linter
+        // so we insert equivalent unicode chars directly.
+        // U+27E8 | ⟨ | \xe2\x9f\xa8 | MATHEMATICAL LEFT ANGLE BRACKET
+        // U+27E9 | ⟩ | \xe2\x9f\xa9 | MATHEMATICAL RIGHT ANGLE BRACKET
         {langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
             regex: openInterval, replace: `($1${sep}$3)`},
         {langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-            regex: closedInterval, replace: `<$1${sep}$3>`},
+            regex: closedInterval, replace: `⟨$1${sep}$3⟩`},
         {langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-            regex: leftClosedInterval, replace: `<$1${sep}$3)`},
+            regex: leftClosedInterval, replace: `⟨$1${sep}$3)`},
         {langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-            regex: rightClosedInterval, replace: `($1${sep}$3>`},
+            regex: rightClosedInterval, replace: `($1${sep}$3⟩`},
     ];
 
     intervalTranslations.forEach(function(el) {

--- a/src/math-translator.js
+++ b/src/math-translator.js
@@ -323,7 +323,7 @@ function normalizeTranslatedMath(math, lang) {
 
     // Remove whitespace in coordinates/intervals
     // Applied to all langs because all langs can be affected by
-    // tranlatedCoordinates/translateIntervals/translateCoordinatesOrIntervals
+    // translatedCoordinates/translateIntervals/translateCoordinatesOrIntervals
     const orderedPair = getOrderedPairRegexString(lang);
     const coordsAndIntervals =
         new RegExp(`([[⟨(\\]])${orderedPair}([[)⟩\\]])`, 'g');
@@ -422,6 +422,12 @@ const KATEX_BASE_COLORS = ['blue', 'gold', 'gray', 'mint', 'green', 'red',
  * We do not return the RegExp object, only the string
  * so that it can be combined into more complicated expressions.
  *
+ * By default, the regex contains two capturing groups:
+ * 1. integer part
+ * 2. decimal part
+ * This can be changed by passing capture=false,
+ * this variant is used to construct regexes for coordinates and intervals.
+ *
  * @param {string} lang The KA locale
  * @param {bool} capture whether to include capturing groups in regex
  * @returns {string} String to be passed into RegExp constructor.
@@ -519,10 +525,14 @@ function getOrderedPairRegexString(lang) {
 
 
 /**
- * Detect closed or half-closed intervals in US math expression.
+ * Detect closed or half-closed intervals in US math expression, such as
+ * '[a,b]', '[1,2)' or '(0,5]'
+ *
+ * (the expression can contain numbers or single-letter variables,
+ * see getOrderedpairRegexString)
  *
  * We cannot detect open intervals, because they have the same
- * notation as cartesian coordinates in the US
+ * notation as cartesian coordinates in the US.
  *
  * @param {string} math English math string
  * @returns {bool} true if math contains at least one interval
@@ -642,6 +652,7 @@ function translateCoordinates(math, template, lang) {
 
 /**
  * Translate notation for intervals (opened, closed, half-closed)
+ * e.g. '(-1,1)', '(0, a]' or '[\blue3,\red4]'
  *
  * @param {string} math A math expression to be translated
  * @param {string} template User-translated template
@@ -719,9 +730,13 @@ function translateIntervals(math, template, lang) {
 
 /**
  * Translate notation of coordinates or open intervals.
+ *
  * Since the US notation is the same, we cannot really distinguish
  * the two apart. So we will detect the notation from the user-translated
  * template and use it. Without the template, we return the same string.
+ *
+ * Example US strings:
+ * '(0,1)', '(a,b)', '(1.4, \red{5.6})'
  *
  * @param {string} math A math expression to be translated
  * @param {string} template User-translated template

--- a/src/math-translator.js
+++ b/src/math-translator.js
@@ -1,6 +1,6 @@
 /**
  * This file contains functions for translating math notation
- * as well as a list of locales that these functions should be applied to
+ * as well as a list of locales that these functions should be applied to.
  */
 
 /**
@@ -13,21 +13,33 @@ const MATH_RULES_LOCALES = {
     THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol',
          'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
     THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el', 'id'],
-    NO_THOUSAND_SEP: ['ko', 'ps', 'ka'],
+    NO_THOUSAND_SEP: ['ko', 'ps', 'ka', 'hy'],
     DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol',
             'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka',
-            'ru', 'ta'],
+            'ru', 'ta', 'hy'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],
     // Notations for repeating decimals - 0.\overline{3}
-    // 0.(3)
-    OVERLINE_AS_DOT: ['bn'],
     // 0.\dot{3}
-    OVERLINE_AS_PARENS: ['az', 'pt-pt'],
+    OVERLINE_AS_DOT: ['bn'],
+    // 0.(3)
+    OVERLINE_AS_PARENS: ['az', 'pt-pt', 'hy', 'pl'],
+
+    // Intervals and cartesian coordinates
+    // (a,b) - US open interval or coordinates
+    // [a,b] - US closed interval
+    // [a,b), (a, b] - US half open interval
+    //
+    // Inverted brackets notation for open intervals
+    // (a,b) -> ]a,b[
+    OPEN_INT_AS_BRACKETS: ['da', 'fr', 'hu', 'pt-pt'],
+    CLOSED_INT_AS_ANGLE_BRACKETS: ['cs'],
+    COORDS_AS_BRACKETS: ['cs'],
     // Binary operators
     // TODO(danielhollas):remove 'bg' from TIMES_AS_CDOT
     // when \mathbin{.} becomes available for them
-    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'sv', 'da', 'bg'],
+    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'hy', 'sv',
+        'da', 'bg'],
     CDOT_AS_TIMES: ['fr', 'ps', 'pt-pt', 'ta'],
     DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'pl', 'it',
             'pt-pt', 'ru', 'nb'],
@@ -40,11 +52,38 @@ const MATH_RULES_LOCALES = {
     CSC_AS_COSSEC: ['pt', 'pt-pt'],
     // Rules conditional on the translated template
     MAYBE_DIV_AS_COLON: ['id', 'lol'],
-    MAYBE_TIMES_AS_CDOT: ['az', 'bn', 'el', 'hi', 'hy', 'id', 'it', 'ja', 'ka',
+    MAYBE_TIMES_AS_CDOT: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka',
             'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
-    MAYBE_CDOT_AS_TIMES: ['az', 'bn', 'el', 'hi', 'hy', 'id', 'it', 'ja', 'ka',
+    MAYBE_CDOT_AS_TIMES: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka',
             'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
 };
+
+
+/**
+ * Translates math notation in English strings to match
+ * notation for a given language, such as thousand separators,
+ * decimal commas, math operators etc.
+ *
+ * This function serves as an interface to all the other functions
+ * in this file.
+ *
+ * @param {string} math math expression to translate
+ * @param {string} template User-translated template
+ * @param {string} lang KA locale of the translation language.
+ * @returns {string} translated math expression.
+ */
+function translateMath(math, template, lang) {
+
+    // Need to call this one first, because the regexes
+    // rely on US number formats
+    math = maybeTranslateMath(math, template, lang);
+
+    math = translateMathOperators(math, lang);
+    math = translateNumbers(math, lang);
+    // This one needs to be last
+    math = translateNumerals(math, lang);
+    return math;
+}
 
 /**
  * Translates western-arabic numerals to others, see:
@@ -90,36 +129,14 @@ function translateNumbers(math, lang) {
 
     // These consts are used only here for manipulating thousand separator
     const placeholder = 'THSEP';
-    const USThousandSeparatorRegex =
+    const thousandSeparatorRegex =
         new RegExp(`([0-9])${placeholder}([0-9])(?=[0-9]{2})`, 'g');
     const thousandSeparatorLocales = [].concat(
             MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
             MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
             MATH_RULES_LOCALES.NO_THOUSAND_SEP);
 
-    // Definition of regex for decimal numbers
-    // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
-    // repeating decimals like '1/3 = 0.\\overline{3}'
-    //
-    // Colors currently used in KA strings taken from KaTeX definitions, see:
-    // https://github.com/KaTeX/KaTeX/blob/master/src/macros.js
-    //
-    // \\overline is handled elsewhere since it appears only
-    // on the right side of the decimal point
-    //
-    // These colors are appended by optional [A-Z]? to match all definitions
-    // from KaTeX. This will form a superset of actually defined colors,
-    // but that hardly matters here and is more future-proof if new colors
-    // were defined at some point
-    const katexColorMacros = ['blue', 'gold', 'gray', 'mint', 'green', 'red',
-         'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen']
-         .join('|');
-
-    const integerPart = `[0-9]+|\\\\(?:${katexColorMacros})[A-Z]?\\{[0-9]+\\}`;
-    const decPart =
-       `[0-9]+|\\\\(?:overline|${katexColorMacros})[A-Z]?\\{[0-9]+\\}`;
-    const decimalNumberRegex =
-      new RegExp(`(${integerPart})\\.(${decPart})`, 'g');
+    const decimalNumberRegex = new RegExp(getDecNumberRegexString('en'), 'g');
 
     const mathTranslations = [
          // IMPORTANT NOTE: This MUST be the first regex
@@ -149,15 +166,15 @@ function translateNumbers(math, lang) {
 
          // No thousand separator
          {langs: MATH_RULES_LOCALES.NO_THOUSAND_SEP,
-            regex: USThousandSeparatorRegex, replace: '$1$2'},
+            regex: thousandSeparatorRegex, replace: '$1$2'},
 
          // Thousand separator as a dot
          {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
-            regex: USThousandSeparatorRegex, replace: '$1.$2'},
+            regex: thousandSeparatorRegex, replace: '$1.$2'},
 
          // Thousand separator as a thin space (\, in Tex)
          {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
-            regex: USThousandSeparatorRegex, replace: '$1\\,$2'},
+            regex: thousandSeparatorRegex, replace: '$1\\,$2'},
     ];
 
     mathTranslations.forEach(function(element) {
@@ -244,22 +261,6 @@ function translateMathOperators(math, lang) {
 }
 
 /**
- * Handles any per language special case translations
- * e.g. thousand separators, decimal commas, math operators etc.
- *
- * @param {string} math A math expression to translate
- * @param {string} lang The KA locale of the translation language.
- * @returns {string} The translated math expression.
- */
-function translateMath(math, lang) {
-    // The order here should not matter
-    math = translateMathOperators(math, lang);
-    math = translateNumbers(math, lang);
-    math = translateNumerals(math, lang);
-    return math;
-}
-
-/**
  * Perform regex substitutions on user-translated math strings
  * for math notations where we permit variations
  * so that it matches math translations done in translateMath().
@@ -342,6 +343,25 @@ function normalizeTranslatedMath(math, lang) {
  * @returns {string} translated math expression.
  */
 function maybeTranslateMath(math, template, lang) {
+
+    // A heuristic for intervals and coordinates:
+    // We assume that a single string will not mix intervals and coordinates
+    // 1. Try to find closed/half-closed intervals
+    // 2. If not found, try to detect coordinates
+    // (for details, see comment for detectCoordinates())
+    // 3. For certain strings such as (1,2), we cannot differentiate
+    // between coordinates and intervals so we will extract the notation
+    // from the translated template.
+    if (detectClosedInterval(math)) {
+        math = translateIntervals(math, template, lang);
+    } else if (detectCoordinates(math)) {
+        math = translateCoordinates(math, template, lang);
+    } else {
+        math = translateCoordinatesOrOpenIntervals(math, template, lang);
+    }
+
+    // The rest of the rules can be applied only
+    // when we have the translated template.
     if (!template) {
         return math;
     }
@@ -371,9 +391,373 @@ function maybeTranslateMath(math, template, lang) {
     return math;
 }
 
+
+/**
+ * Base colors currently used in KA strings taken from KaTeX definitions, see:
+ * https://github.com/KaTeX/KaTeX/blob/master/src/macros.js
+ * There can be different variants of a single color, such as \redA or \blueD,
+ * but that's handled elsewhere.
+ */
+const KATEX_BASE_COLORS = ['blue', 'gold', 'gray', 'mint', 'green', 'red',
+         'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen'];
+
+/**
+ * Construct regular expression to match decimal numbers for a given lang,
+ * possibly wrapped in TeX commands.
+ *
+ * We do not return the RegExp object, only the string
+ * so that it can be combined into more complicated expressions.
+ *
+ * @param {string} lang The KA locale
+ * @param {bool} capture whether to include capturing groups in regex
+ * @returns {string} String to be passed into RegExp constructor.
+ */
+function getDecNumberRegexString(lang, capture = true) {
+    // Definition of regex for decimal numbers
+    // We need to allow for strings like '\\greenD{3}.\\blue{1}' or
+    // repeating decimals like '1/3 = 0.\\overline{3}'
+    //
+    // These colors are appended by optional [A-Z]? to match all definitions
+    // from KaTeX. This will form a superset of actually defined colors,
+    // but that hardly matters here and is more future-proof if new colors
+    // were defined at some point
+    const katexColorMacros = KATEX_BASE_COLORS.join('|');
+
+    const integerPart = `[0-9]+|\\\\(?:${katexColorMacros})[A-Z]?\\{[0-9]+\\}`;
+    // Decimal part is different from integer part
+    // because it can contain \\overline
+    // TODO: Some langs do not use \\overline, but \\dot
+    const decPart =
+       `[0-9]+|\\\\(?:overline|${katexColorMacros})[A-Z]?\\{[0-9]+\\}`;
+
+    const sep = getEscapedDecimalSeparator(lang);
+
+    // This part matches strings like `\\green{1.2}`
+    const wrappedDecimal =
+        `\\\\(?:${katexColorMacros})[A-Z]?\\{-?[0-9]+${sep}[0-9]+\\}`;
+
+    // Wrapped decimal is not needed if we capture integer and decimal part
+    // because in that case we do not care that the decimal number
+    // is wrapped as a whole
+    return capture ?
+        `(${integerPart})${sep}(${decPart})` :
+        `(?:(?:${integerPart})${sep}(?:${decPart}))|(?:${wrappedDecimal})`;
+}
+
+/**
+ * Return decimal separator for a given language.
+ * The separator is used in regex so it needs to be escaped.
+ *
+ * @param {string} lang KA locale
+ * @returns {string} Decimal separator to be passed into RegExp constructor.
+ */
+function getEscapedDecimalSeparator(lang) {
+    if (MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang)) {
+        return '\\{,\\}';
+    } else if (MATH_RULES_LOCALES.ARABIC_COMMA.includes(lang)) {
+        return '\\{،\\}';
+    } else {
+        return '\\.';
+    }
+}
+
+/**
+ * Build regex string for ranges (inside intervals)
+ * or, equivalently, cartesian coordinates (without parentheses).
+ *
+ * Matches strings such as:
+ * '-1,0'
+ * '1.2;3'
+ * '\greenD4, \blue{1{,}2}'
+ * 'x,y'
+ *
+ * We pass in the language param, because we need to match
+ * different notations for decimal numbers
+ *
+ * @param {string} lang KA locale
+ * @returns {string} string to be passed to RegExp constructor
+ */
+function getRangeRegexString(lang) {
+    const katexColorMacros = `\\\\(?:${KATEX_BASE_COLORS.join('|')})[A-Z]?`;
+    // Assuming single-letter variables and numbers below 1000
+    // (without thousand separator)
+    const integer =
+      `-?[0-9]+|-?${katexColorMacros}\\{-?[0-9]+\\}|-?${katexColorMacros}[0-9]`;
+    const variable = `[a-z]|${katexColorMacros}\\{[a-z]\\}`;
+    const decimal = getDecNumberRegexString(lang,
+                /* don't include capture groups */ false);
+    const numberOrLetter = `${variable}|${decimal}|${integer}`;
+    // NOTE(danielhollas): We allow comma and semicolon for all langs
+    // as separators, even though maybe some langs use only comma.
+    // Since the US strings always have commas (I think),
+    // it's not a big deal if we are more permissive.
+    // If a translator bothered to change it to semicolon,
+    // they probably had a reason.
+    let separators = ',;';
+    if (lang === 'de') {
+        separators += '|'; // For German coordinates
+    }
+    // Support LaTeX spaces, e.g. '4~; 3' (used in e.g. French notation)
+    const space = `(?:\\\\,|~|\\s)*`;
+    const sep = `${space}[${separators}]${space}`;
+    return `\\s*(${numberOrLetter})(${sep})(${numberOrLetter})\\s*`;
+}
+
+
+/**
+ * Detect closed or half-closed intervals in US math expression.
+ *
+ * We cannot detect open intervals, because they have the same
+ * notation as cartesian coordinates in the US
+ *
+ * @param {string} math English math string
+ * @returns {bool} true if math contains at least one interval
+ */
+function detectClosedInterval(math) {
+    const lang = 'en';
+    const interval = getRangeRegexString(lang);
+    const closedInterval = `\\[${interval}\\]`;
+    const leftClosedInterval = `\\[${interval}\\)`;
+    const rightClosedInterval = `\\(${interval}\\]`;
+    return math.match(closedInterval) ||
+        math.match(leftClosedInterval) ||
+        math.match(rightClosedInterval);
+}
+
+/**
+ * A heuristic for detecting cartesian coordinates in US math expressions.
+ *
+ * Given `(a,b)`, an interval would always have a < b
+ * (4, 2) is a coordinate
+ * (2, 4) may be coordinate or open interval so we return false
+ * (x, y) can also be coordinate or open interval so we return false
+ *
+ * @param {string} math English math string
+ * @returns {bool} true if math definitely contains cartesian coordinates
+ */
+function detectCoordinates(math) {
+    const lang = 'en';
+    const coords = getRangeRegexString(lang);
+    const coordsRegex = new RegExp(`\\(${coords}\\)`, 'g');
+    let match;
+    while ( (match = coordsRegex.exec(math)) !== null &&
+        match.length === 4) {
+        // Remove color commands around numbers
+        const num1 = match[1].replace(/[a-zA-Z]|\{|\}|\\/g, '');
+        const num2 = match[3].replace(/[a-zA-Z]|\{|\}|\\/g, '');
+        const a = parseFloat(num1);
+        const b = parseFloat(num2);
+        if (a >= b) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Extract the separator from a translated template.
+ * If empty, the default separator is used.
+ *
+ * Regular expression is passed in that matches coordinates/intervals
+ * in a given language. The separator is captured in the second group.
+ *
+ * @param {string} template User-translated template (optional)
+ * @param {string} regex Regular expression matching coordinates/intervals
+ * @param {string} lang KA locale of the translation language.
+ * @returns {string} Translated string
+ */
+function getSeparator(template, regex, lang) {
+    let sepDefault = ',';
+    // Languages with decimal comma typically use semicolon
+    if (MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang)) {
+        sepDefault = ';';
+    }
+    let match;
+    // Return separator from the template if detected
+    if (template &&
+        (match = template.match(regex)) !== null &&
+        match.length === 4) {
+        return match[2];
+    } else {
+        return sepDefault;
+    }
+}
+
+/**
+ * Translates notation for cartesian coordinates, such as:
+ * (3,0) or (x,y)
+ *
+ * A translated template is used to determine the separator.
+ * If empty, the default separator is used.
+ *
+ * @param {string} math A math expression to be translated
+ * @param {string} template User-translated template (optional)
+ * @param {string} lang The KA locale of the translation language.
+ * @returns {string} Translated string
+ */
+function translateCoordinates(math, template, lang) {
+    const coordsUS = getRangeRegexString('en');
+    const coordsRegexUS = new RegExp(`\\(${coordsUS}\\)`, 'g');
+
+    const coords = getRangeRegexString(lang);
+    let coordsRegex;
+    if (MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang)) {
+        coordsRegex = new RegExp(`\\[${coords}\\]`);
+    } else {
+        coordsRegex = new RegExp(`\\(${coords}\\)`);
+    }
+
+    const sep = getSeparator(template, coordsRegex, lang);
+
+    const coordsTranslations = [
+        {langs: MATH_RULES_LOCALES.COORDS_AS_BRACKETS,
+            regex: coordsRegexUS, replace: `[$1${sep}$3]`},
+    ];
+
+    coordsTranslations.forEach(function(el) {
+        if (el.langs.includes(lang)) {
+            math = math.replace(el.regex, el.replace);
+        } else {
+            // For all other langs translate only the separator
+            math = math.replace(el.regex, `($1${sep}$3)`);
+        }
+    });
+
+    return math;
+}
+
+/**
+ * Translate notation for intervals (opened, closed, half-closed)
+ *
+ * @param {string} math A math expression to be translated
+ * @param {string} template User-translated template
+ * @param {string} lang The KA locale of the translation language.
+ * @returns {string} Translated string
+ */
+function translateIntervals(math, template, lang) {
+    const intervalUS = getRangeRegexString('en');
+    const closedInterval = new RegExp(`\\[${intervalUS}\\]`, 'g');
+    const openInterval = new RegExp(`\\(${intervalUS}\\)`, 'g');
+    const leftClosedInterval = new RegExp(`\\[${intervalUS}\\)`, 'g');
+    const rightClosedInterval = new RegExp(`\\(${intervalUS}\\]`, 'g');
+
+    // Detect range separator in the template, can be comma or semicolon
+    // We expect that if template contains more intervals, they will have
+    // the same separator. The can also include any whitespace chars.
+    // Again, these need to be consistent in all intervals!
+    const interval = getRangeRegexString(lang);
+    const generalInterval = new RegExp(`[[(\\]]${interval}[[)\\]]`);
+
+    const sep = getSeparator(template, generalInterval, lang);
+
+    const intervalTranslations = [
+        // open intervals with inverted brackets
+        {langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+            regex: openInterval, replace: `]$1${sep}$3[`},
+        {langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+            regex: closedInterval, replace: `[$1${sep}$3]`},
+        {langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+            regex: leftClosedInterval, replace: `[$1${sep}$3[`},
+        {langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+            regex: rightClosedInterval, replace: `]$1${sep}$3]`},
+    ];
+
+    intervalTranslations.forEach(function(el) {
+        if (el.langs.includes(lang)) {
+            math = math.replace(el.regex, el.replace);
+        }
+    });
+
+    // For all other languages not listed above,
+    // translated only the separator
+    if (MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang)) {
+        return math;
+    }
+
+    // The only thing we translate here is the separator!
+    const separatorTranslations = [
+        {regex: openInterval, replace: `($1${sep}$3)`},
+        {regex: closedInterval, replace: `[$1${sep}$3]`},
+        {regex: leftClosedInterval, replace: `[$1${sep}$3)`},
+        {regex: rightClosedInterval, replace: `($1${sep}$3]`},
+    ];
+
+    separatorTranslations.forEach(function(el) {
+        math = math.replace(el.regex, el.replace);
+    });
+
+    return math;
+}
+
+/**
+ * Translate notation of coordinates or open intervals.
+ * Since the US notation is the same, we cannot really distinguish
+ * the two apart. So we will detect the notation from the user-translated
+ * template and use it. Without the template, we return the same string.
+ *
+ * @param {string} math A math expression to be translated
+ * @param {string} template User-translated template
+ * @param {string} lang Khan language
+ * @returns {string} translated string
+ */
+function translateCoordinatesOrOpenIntervals(math, template, lang) {
+    if (!template) {
+        return math;
+    }
+    const rangeUS = getRangeRegexString('en');
+    const coordsOrOpenIntervalUS = new RegExp(`\\(${rangeUS}\\)`, 'g');
+
+    // First look into the English string
+    let match = math.match(coordsOrOpenIntervalUS);
+    if (!match) {
+        return math;
+    }
+    // Now we know that the English string contains coordinates or intervals
+    // Let's detect them in the template, if we fail,
+    // we return prematurely
+    const range = getRangeRegexString(lang);
+    const coordsOrOpenInterval = new RegExp(`([[(\\]])${range}([[)\\]])`);
+    match = template.match(coordsOrOpenInterval);
+    if (!match || match.length !== 6) {
+        return math;
+    }
+
+    const left = match[1];
+    const sep = match[3];
+    const right = match[5];
+
+    // Verify that left and right parentheses|brackets make sense
+    // for a given language
+    switch(left) {
+    case '[':
+        if (right !== ']' ||
+            !MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang))
+            return math;
+        break;
+    case ']':
+        if (right !== '[' ||
+            !MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang))
+            return math;
+        break;
+    case '(':
+        if (right !== ')')
+            return math;
+        break;
+    default:
+        return math;
+    }
+
+    const replace = `${left}$1${sep}$3${right}`;
+
+    return math.replace(coordsOrOpenIntervalUS, replace);
+}
+
 module.exports = {
     translateMath: translateMath,
+    // The following are exported only for testing
     maybeTranslateMath: maybeTranslateMath,
     normalizeTranslatedMath: normalizeTranslatedMath,
     MATH_RULES_LOCALES: MATH_RULES_LOCALES,
+    detectClosedInterval: detectClosedInterval,
+    detectCoordinates: detectCoordinates,
 };

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -5,7 +5,6 @@
 const {
     translateMath,
     normalizeTranslatedMath,
-    maybeTranslateMath,
 } = require('./math-translator');
 
 // Matches math delimited by $, e.g.
@@ -144,8 +143,7 @@ function getMapping(
         // from the entire template
         const allTranslatedMaths = outputs.join(' ');
         inputs = inputs
-            .map((input) => maybeTranslateMath(input, allTranslatedMaths, lang))
-            .map((input) => translateMath(input, lang))
+            .map((input) => translateMath(input, allTranslatedMaths, lang))
             .map((input) => replaceTextInMath(input, mathDictionary));
     }
 
@@ -234,6 +232,8 @@ function getMathDictionary(englishStr, translatedStr, lang) {
     // Used in maybeTranslateMath() to pattern-match the translated math
     // from the entire template
     const allTranslatedMaths = outputs.join(' ');
+    inputs = inputs.map((input) =>
+        translateMath(input, allTranslatedMaths, lang));
 
     const inputMap = {};
     const outputMap = {};
@@ -242,10 +242,6 @@ function getMathDictionary(englishStr, translatedStr, lang) {
         [TEXT_REGEX, '__TEXT__'],
         [TEXTBF_REGEX, '__TEXTBF__'],
     ];
-
-    inputs = inputs
-        .map((input) => maybeTranslateMath(input, allTranslatedMaths, lang))
-        .map((input) => translateMath(input, lang));
 
     inputs.forEach((input) => {
         let normalized = input;
@@ -480,8 +476,8 @@ function populateTemplate(template, englishStr, lang) {
     const images = englishStr.match(IMAGE_REGEX) || [];
     const widgets = englishStr.match(WIDGET_REGEX) || [];
 
-    // Used in maybeTranslateMath() to pattern-match the translated math
-    // from the entire template
+    // Used in maybeTranslateMath() (called in translateMath)
+    // to pattern-match the translated math from the entire template
     const allTranslatedMaths = template.translatedMaths.join(' ');
 
     let mathIndex = 0;
@@ -490,8 +486,7 @@ function populateTemplate(template, englishStr, lang) {
     let widgetIndex = 0;
 
     maths = maths
-      .map((math) => maybeTranslateMath(math, allTranslatedMaths, lang))
-      .map((math) => translateMath(math, lang))
+      .map((math) => translateMath(math, allTranslatedMaths, lang))
       .map((math) => replaceTextInMath(math, template.mathDictionary));
 
     return englishLines.map((englishLine, index) => {
@@ -609,7 +604,7 @@ class TranslationAssistant {
                 // Only translate the math if it doesn't include any
                 // natural language text in \text and \textbf commands.
                 if (englishStr.indexOf('\\text') === -1) {
-                    return [item, translateMath(englishStr, lang)];
+                    return [item, translateMath(englishStr, '', lang)];
                 }
             }
 

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -464,6 +464,8 @@ function populateTemplate(template, englishStr, lang) {
             englishMapping = getMapping(
                 englishStr, englishStr, 'en', MATH_REGEX, englishDictionary);
         } catch (error) {
+            console.error(  // eslint-disable-line no-console
+                'Unexpected error in TranslationAssistant.populateTemplate');
             return undefined;
         }
         // And verify that the math mapping is identical to the one in the

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -454,8 +454,18 @@ function populateTemplate(template, englishStr, lang) {
         // string.
         const englishDictionary = getMathDictionary(
             englishStr, englishStr, lang);
-        const englishMapping = getMapping(
-            englishStr, englishStr, 'en', MATH_REGEX, englishDictionary);
+
+        let englishMapping;
+
+        // This call to getMapping() should be safe because we're
+        // comparing English string with itself. Nevertheless, we're cautious
+        // so we don't crash the Translation Editor.
+        try {
+            englishMapping = getMapping(
+                englishStr, englishStr, 'en', MATH_REGEX, englishDictionary);
+        } catch (error) {
+            return undefined;
+        }
         // And verify that the math mapping is identical to the one in the
         // template.
         if (JSON.stringify(englishMapping) !== JSON.stringify(

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -547,10 +547,10 @@ describe('TranslationAssistant (math-translate)', function() {
             translatedStr: 'simplifyz $2{,}3$',
         }];
         const itemsToTranslate = [{
-            englishStr: 'simplify $2.9$',
+            englishStr: 'simplify $\\red{2.9}$',
             translatedStr: '',
         }];
-        const translatedStrs = ['simplifyz $2{,}9$'];
+        const translatedStrs = ['simplifyz $\\red{2{,}9}$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'fr');
     });
@@ -871,9 +871,7 @@ describe('TranslationAssistant (math-translate)', function() {
 describe('TranslationAssistant (maybe-math-translate)', function() {
 
     it('should translate math according to a template', function() {
-        // Lang 'id' is in both MAYBE_TIMES_AS_CDOT and MAYBE_DIV_AS_COLON
         const lang = 'id';
-
         assert(MATH_RULES_LOCALES.MAYBE_TIMES_AS_CDOT.includes(lang));
         assert(MATH_RULES_LOCALES.MAYBE_DIV_AS_COLON.includes(lang));
 
@@ -949,8 +947,10 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
     });
 
     it('should translate only math present in the template', function() {
-        // Lang 'id' is in both MAYBE_TIMES_AS_CDOT and MAYBE_DIV_AS_COLON
         const lang = 'id';
+        assert(MATH_RULES_LOCALES.MAYBE_TIMES_AS_CDOT.includes(lang));
+        assert(MATH_RULES_LOCALES.MAYBE_DIV_AS_COLON.includes(lang));
+
         const allItems = [
             {englishStr: '$6 \\div 3$',
              translatedStr: '$6 \\mathbin{:} 3$',
@@ -1020,6 +1020,88 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
     */
+
+    it('should translate closed intervals in math-only strings', function() {
+        const lang = 'fr';
+        assert(MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang));
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
+
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$(1,2) [2,b] [a,c) (1.2,5]$', translatedStr: ''},
+        ];
+        const translatedStrs = ['$]1;2[ [2;b] [a;c[ ]1{,}2;5]$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    it('should detect and translate coordinates in math-only strings',
+    function() {
+        const lang = 'cs';
+        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
+
+        const allItems = [];
+        const itemsToTranslate = [
+            {englishStr: '$(2,1) (x,y) (\\green4,1.5)$', translatedStr: ''},
+        ];
+        const translatedStrs = ['$[2;1] [x;y] [\\green4;1{,}5]$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    it('should translate both coordinates and intervals in separate math bits',
+    function() {
+        const lang = 'cs';
+        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
+
+        const allItems = [
+            {englishStr: 'Intervals $[0,3] (-1,3)$ coordinates $(0,0)$',
+            translatedStr: 'Ints $[0;3] (-1;3)$ coords $[0;0]$'},
+        ];
+        const itemsToTranslate = [
+            {englishStr: 'Intervals $[0,3) [-5,\\red3)$ coordinates $(-1,-1)$',
+            translatedStr: ''},
+        ];
+        const translatedStrs = ['Ints $[0;3) [-5;\\red3)$ coords $[-1;-1]$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    it('should translate open intervals according to a template', function() {
+        const lang = 'fr';
+        assert(MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang));
+
+        const allItems = [
+            {englishStr: 'Open intervals $(0,3) (\\blueD{-1},0)$',
+            translatedStr: 'Ints $]0~;3[ ]\\blueD{-1}~;0[$'},
+        ];
+        const itemsToTranslate = [
+            {englishStr: 'Open intervals $(0,3)$',
+            translatedStr: ''},
+        ];
+        const translatedStrs = ['Ints $]0~;3[$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    it('should translate coordinates according to a template', function() {
+        const lang = 'cs';
+        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
+
+        const allItems = [
+            {englishStr: 'Coordinates $(0,3.\\overline{3}) (\\blueD{-1},0)$',
+            translatedStr: 'Coords $[0;3{,}\\overline{3}] [\\blueD{-1};0]$'},
+        ];
+        const itemsToTranslate = [
+            {englishStr: 'Coordinates $(0,3)$',
+            translatedStr: ''},
+        ];
+        const translatedStrs = ['Coords $[0;3]$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
 });
 
 describe('TranslationAssistant (graphie)', function() {

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -1054,16 +1054,18 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
     function() {
         const lang = 'cs';
         assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
+        assert(MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS.includes(lang));
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
 
         const allItems = [
             {englishStr: 'Intervals $[0,3] (-1,3)$ coordinates $(0,0)$',
-            translatedStr: 'Ints $[0;3] (-1;3)$ coords $[0;0]$'},
+            translatedStr: 'Ints $<0;3> (-1;3)$ coords $[0;0]$'},
         ];
         const itemsToTranslate = [
-            {englishStr: 'Intervals $[0,3) [-5,\\red3)$ coordinates $(-1,-1)$',
+            {englishStr: 'Intervals $[0,3) (-5,\\red3]$ coordinates $(-1,-1)$',
             translatedStr: ''},
         ];
-        const translatedStrs = ['Ints $[0;3) [-5;\\red3)$ coords $[-1;-1]$'];
+        const translatedStrs = ['Ints $<0;3) (-5;\\red3>$ coords $[-1;-1]$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -1059,13 +1059,13 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
 
         const allItems = [
             {englishStr: 'Intervals $[0,3] (-1,3)$ coordinates $(0,0)$',
-            translatedStr: 'Ints $<0;3> (-1;3)$ coords $[0;0]$'},
+            translatedStr: 'Ints $⟨0;3⟩ (-1;3)$ coords $[0;0]$'},
         ];
         const itemsToTranslate = [
             {englishStr: 'Intervals $[0,3) (-5,\\red3]$ coordinates $(-1,-1)$',
             translatedStr: ''},
         ];
-        const translatedStrs = ['Ints $<0;3) (-5;\\red3>$ coords $[-1;-1]$'];
+        const translatedStrs = ['Ints $⟨0;3) (-5;\\red3⟩$ coords $[-1;-1]$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -1050,6 +1050,40 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
 
+    it('should handle superflous spaces in English coordinates', function() {
+        const lang = 'cs';
+        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
+
+        const allItems = [
+            {englishStr: 'coordinates $( 0,1)$',
+             translatedStr: 'souradnice $[0;1]$'},
+        ];
+        const itemsToTranslate = [
+            {englishStr: 'coordinates $( 2, 1)$', translatedStr: ''},
+        ];
+        const translatedStrs = ['souradnice $[2;1]$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
+    it('should handle superflous spaces in translated coordinates', function() {
+        const lang = 'cs';
+        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
+
+        const allItems = [
+            {englishStr: 'coordinates $(0,1 )$',
+             translatedStr: 'souradnice $[0; 1 ]$'},
+        ];
+        const itemsToTranslate = [
+            {englishStr: 'coordinates $(2,1)$', translatedStr: ''},
+        ];
+        const translatedStrs = ['souradnice $[2; 1]$'];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
     it('should translate both coordinates and intervals in separate math bits',
     function() {
         const lang = 'cs';

--- a/tests/math_translator_spec.js
+++ b/tests/math_translator_spec.js
@@ -320,6 +320,15 @@ describe('MathTranslator (normalizeTranslatedMath)', function() {
         const outputStr2 = normalizeTranslatedMath(translatedStr2, 'az');
         assert.equal(outputStr2, normalizedStr2);
     });
+
+    it('should strip extra space in coordinates/intervals',
+    function() {
+        // Striping space after opening brackets and before closing brackets
+        const translatedStr = '( 1,2 ) [ 3; 4] ] 1~,2[ ⟨ a;\\red5 ⟩';
+        const normalizedStr = '(1,2) [3; 4] ]1~,2[ ⟨a;\\red5⟩';
+        const outputStr = normalizeTranslatedMath(translatedStr, 'cs');
+        assert.equal(outputStr, normalizedStr);
+    });
 });
 
 describe('MathTranslator (maybeTranslateMath)', function() {

--- a/tests/math_translator_spec.js
+++ b/tests/math_translator_spec.js
@@ -574,11 +574,12 @@ describe('MathTranslator (maybeTranslateMath)', function() {
         assert(
             MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS.includes(locale)
         );
+        // With languages with decimal comma get semicolon as default separator
         assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(locale));
 
-        const englishStr = '(a, b) [1,2) (1,2.1] [ \\red4, 5]';
+        const englishStr = '(a, b) [1,2) (1,2.1] [ a, \\red5]';
         const template = '';
-        const translatedStr = '(a;b) <1;2) (1;2.1> <\\red4;5>';
+        const translatedStr = '(a;b) ⟨1;2) (1;2.1⟩ ⟨a;\\red5⟩';
         const output = maybeTranslateMath(englishStr, template, locale);
         assert.equal(output, translatedStr);
     });

--- a/tests/math_translator_spec.js
+++ b/tests/math_translator_spec.js
@@ -5,13 +5,15 @@ const {
     translateMath,
     maybeTranslateMath,
     normalizeTranslatedMath,
+    detectClosedInterval,
+    detectCoordinates,
     MATH_RULES_LOCALES,
 } = require('../lib/math-translator');
 
 describe('MathTranslator (translateMath)', function() {
     it('should return the same string for en locale', function() {
         const englishStr = '1{,}000{,}000 \\times 9{,}000.400 \\div 2 = \\sin';
-        const outputStr = translateMath(englishStr, 'en');
+        const outputStr = translateMath(englishStr, '', 'en');
         assert.equal(outputStr, englishStr);
     });
 
@@ -20,7 +22,7 @@ describe('MathTranslator (translateMath)', function() {
         const translatedStr = '1\\,000\\,000 + 9\\,000';
 
         MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.forEach(function(locale) {
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -30,7 +32,7 @@ describe('MathTranslator (translateMath)', function() {
         const translatedStr = '1.000.000 + 9.000';
 
         MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT.forEach(function(locale) {
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -39,13 +41,13 @@ describe('MathTranslator (translateMath)', function() {
         const englishStr = '1{,}000{,}000 + 9{,}000';
         const translatedStr = '1000000 + 9000';
 
-        const outputStr = translateMath(englishStr, 'ko');
+        const outputStr = translateMath(englishStr, '', 'ko');
         assert.equal(outputStr, translatedStr);
     });
 
     it('should not translate thousand separator for en locale', function() {
         const englishStr = '1{,}000{,}000 + 9{,}000';
-        const outputStr = translateMath(englishStr, 'en');
+        const outputStr = translateMath(englishStr, '', 'en');
         assert.equal(outputStr, englishStr);
     });
 
@@ -54,7 +56,7 @@ describe('MathTranslator (translateMath)', function() {
         const translatedStr = '1000{,}000 + 9{,}4 + 45{,}0';
 
         MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -63,7 +65,7 @@ describe('MathTranslator (translateMath)', function() {
     function() {
         const englishStr = '1{,}000{,}000.700 + 9{,}000.000';
         const translatedStr = '1\\,000\\,000{,}700 + 9\\,000{,}000';
-        const outputStr = translateMath(englishStr, 'cs');
+        const outputStr = translateMath(englishStr, '', 'cs');
         assert.equal(outputStr, translatedStr);
     });
 
@@ -71,7 +73,7 @@ describe('MathTranslator (translateMath)', function() {
         MATH_RULES_LOCALES.TIMES_AS_CDOT.forEach(function(locale) {
             const englishStr = '2 \\times 2 = 4';
             const translatedStr = '2 \\cdot 2 = 4';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
 
@@ -80,7 +82,7 @@ describe('MathTranslator (translateMath)', function() {
             // CDOT_AS_TIMES includes Pashto which has different numerals
             const englishStr = 'a \\cdot b';
             const translatedStr = 'a \\times b';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -89,7 +91,7 @@ describe('MathTranslator (translateMath)', function() {
         MATH_RULES_LOCALES.DIV_AS_COLON.forEach(function(locale) {
             const englishStr = '8 \\div 2 = 4';
             const translatedStr = '8 \\mathbin{:} 2 = 4';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -97,7 +99,7 @@ describe('MathTranslator (translateMath)', function() {
     it('should translate different math notations simultaneously', function() {
         const englishStr = '8\\div 2=2 \\times 2, 1{,}000{,}000.874';
         const translatedStr = '8\\mathbin{:} 2=2 \\cdot 2, 1\\,000\\,000{,}874';
-        const outputStr = translateMath(englishStr, 'cs');
+        const outputStr = translateMath(englishStr, '', 'cs');
         assert.equal(outputStr, translatedStr);
     });
 
@@ -106,7 +108,7 @@ describe('MathTranslator (translateMath)', function() {
         MATH_RULES_LOCALES.SIN_AS_SEN.forEach(function(locale) {
             const englishStr = '\\arcsin \\sin';
             const translatedStr = '\\operatorname{arcsen} \\operatorname{sen}';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -115,7 +117,7 @@ describe('MathTranslator (translateMath)', function() {
         MATH_RULES_LOCALES.TAN_AS_TG.forEach(function(locale) {
             const englishStr = '\\arctan\\tan';
             const translatedStr = '\\operatorname{arctg}\\operatorname{tg}';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -124,14 +126,14 @@ describe('MathTranslator (translateMath)', function() {
         MATH_RULES_LOCALES.COT_AS_COTG.forEach(function(locale) {
             const englishStr = '\\arccot\\cot';
             const translatedStr = '\\operatorname{arccotg}\\operatorname{cotg}';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
 
         MATH_RULES_LOCALES.COT_AS_CTG.forEach(function(locale) {
             const englishStr = '\\arccot\\cot';
             const translatedStr = '\\operatorname{arcctg}\\operatorname{ctg}';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -140,14 +142,14 @@ describe('MathTranslator (translateMath)', function() {
         MATH_RULES_LOCALES.CSC_AS_COSSEC.forEach(function(locale) {
             const englishStr = '\\csc \\theta';
             const translatedStr = '\\operatorname{cossec} \\theta';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
 
         MATH_RULES_LOCALES.CSC_AS_COSEC.forEach(function(locale) {
             const englishStr = '\\csc \\theta';
             const translatedStr = '\\operatorname{cosec} \\theta';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -156,7 +158,7 @@ describe('MathTranslator (translateMath)', function() {
         MATH_RULES_LOCALES.PERSO_ARABIC_NUMERALS.forEach(function(locale) {
             const englishStr = '1234567890';
             const translatedStr = '۱۲۳۴۵۶۷۸۹۰';
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -165,7 +167,7 @@ describe('MathTranslator (translateMath)', function() {
     function() {
         const englishStr = '1{,}234{,}567.890';
         const translatedStr = '۱۲۳۴۵۶۷{،}۸۹۰';
-        const outputStr = translateMath(englishStr, 'ps');
+        const outputStr = translateMath(englishStr, '', 'ps');
         assert.equal(outputStr, translatedStr);
     });
 
@@ -178,12 +180,12 @@ describe('MathTranslator (translateMath)', function() {
 
         const englishStr = '1.\\overline{3} + 9.\\overline{44}';
         let translatedStr = '1{,}\\overline{3} + 9{,}\\overline{44}';
-        const outputStr = translateMath(englishStr, locale);
+        const outputStr = translateMath(englishStr, '', locale);
         assert.equal(outputStr, translatedStr);
 
         translatedStr = '۱{،}\\overline{۳} + ۹{،}\\overline{۴۴}';
         MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -195,7 +197,7 @@ describe('MathTranslator (translateMath)', function() {
 
         const englishStr = '1.\\overline{3} + 9.\\overline{44}';
         const translatedStr = '1.\\dot{3} + 9.\\dot{4}\\dot{4}';
-        const outputStr = translateMath(englishStr, locale);
+        const outputStr = translateMath(englishStr, '', locale);
         assert.equal(outputStr, translatedStr);
     });
 
@@ -206,7 +208,7 @@ describe('MathTranslator (translateMath)', function() {
 
         const englishStr = '1.\\overline{3} + 9.\\overline{44}';
         const translatedStr = '1{,}(3) + 9{,}(44)';
-        const outputStr = translateMath(englishStr, locale);
+        const outputStr = translateMath(englishStr, '', locale);
         assert.equal(outputStr, translatedStr);
     });
 
@@ -217,14 +219,14 @@ describe('MathTranslator (translateMath)', function() {
          '\\blue{13}{,}\\tealE{3} \\tealE{9}{,}\\blue{4} \\redA{0}{,}\\red{33}';
 
         MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
 
         translatedStr =
          '\\blue{۱۳}{،}\\tealE{۳} \\tealE{۹}{،}\\blue{۴} \\redA{۰}{،}\\red{۳۳}';
         MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -234,13 +236,13 @@ describe('MathTranslator (translateMath)', function() {
         let translatedStr = englishStr;
 
         MATH_RULES_LOCALES.DECIMAL_COMMA.forEach(function(locale) {
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
 
         translatedStr = '\\hat{۱}.\\tealE{۳} \\tealE{۹}.\\hat{۴}';
         MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
-            const outputStr = translateMath(englishStr, locale);
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
     });
@@ -406,6 +408,280 @@ describe('MathTranslator (maybeTranslateMath)', function() {
             assert.equal(output, translatedStr);
         });
     });
+
+    it('should translate open intervals with inverted brackets', function() {
+        MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.forEach(function(locale) {
+            const englishStr = '[a, b] [1 ,d) (e , 2] (1,2)';
+            const template = ']a,b[';
+            const translatedStr = '[a,b] [1,d[ ]e,2] ]1,2[';
+            const output = maybeTranslateMath(englishStr, template, locale);
+            assert.equal(output, translatedStr);
+        });
+    });
+
+    it('should handle semicolon as a range separator', function() {
+        MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.forEach(function(locale) {
+            const englishStr = '[a, b] [1 ,d) (e , 2] (1,2)';
+            const template = ']a;b[';
+            const translatedStr = '[a;b] [1;d[ ]e;2] ]1;2[';
+            const output = maybeTranslateMath(englishStr, template, locale);
+            assert.equal(output, translatedStr);
+        });
+    });
+
+    it('should handle white space in coordinates/intervals', function() {
+        MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.forEach(function(locale) {
+            const englishStr = '[a, b] [1 ,d) ( e , 2] (1,2 )';
+            const template = ']a ; b[';
+            const translatedStr = '[a ; b] [1 ; d[ ]e ; 2] ]1 ; 2[';
+            const output = maybeTranslateMath(englishStr, template, locale);
+            assert.equal(output, translatedStr);
+
+            const template2 = ']a, b[';
+            const translatedStr2 = '[a, b] [1, d[ ]e, 2] ]1, 2[';
+            const output2 = maybeTranslateMath(englishStr, template2, locale);
+            assert.equal(output2, translatedStr2);
+        });
+    });
+
+    it('should support semicolon as separator for all langs', function() {
+        const locale = 'cs';
+        assert(!MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(locale));
+
+        const englishStr = '[a, b] [1 ,d) (e , 2] (1,2)';
+        const template = '(a; b]';
+        const translatedStr = '[a; b] [1; d) (e; 2] (1; 2)';
+        const output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+    });
+
+    it('should support pipe as separator for german', function() {
+        const locale = 'de';
+
+        const englishStr = '(a, b) (1,2)';
+        // This is a german notation for coordinates
+        const template = '(2|4)';
+        const translatedStr = '(a|b) (1|2)';
+        const output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+    });
+
+    it('should translate separator in closed intervals', function() {
+        // Locales with identical notation for intervals
+        // except that they use semicolon instead of a comma
+        const locale = 'hy';
+        assert(!MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(locale));
+
+        const englishStr = '(a, b) [1,2]';
+        const template = '(2; 4)';
+        const translatedStr = '(a; b) [1; 2]';
+        const output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+    });
+
+    it('should support coordinates with brackets', function() {
+        const locale = 'cs';
+        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(locale));
+
+        let englishStr = '(a, b) (2,1)';
+        let translatedStr = '[a,b] [2,1]';
+        // In this case we now the string contains coordinates,
+        // so we don't need a template
+        let output = maybeTranslateMath(englishStr, null, locale);
+
+        // When we have a template, we should extract the separator
+        let template = '[a;b]';
+        translatedStr = '[a;b] [2;1]';
+        output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+
+        // Here we do not know whether it's an interval or a coordinate
+        // so we need to have the template
+        englishStr = '(a, b) (2,1)';
+        template = '[1; 2]';
+        translatedStr = '[a; b] [2; 1]';
+        output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+    });
+
+    it('should handle different decimal notation in template', function() {
+        const locale = 'cs';
+        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(locale));
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(locale));
+
+        const englishStr = '(a, b) (2,4)';
+        const template = '[1;2{,}5]';
+        const translatedStr = '[a;b] [2;4]';
+        const output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+
+        const englishStr2 = '(a, b) (\\blueD{-8} , \\goldD{6})';
+        const translatedStr2 = '[a;b] [\\blueD{-8};\\goldD{6}]';
+        const output2 = maybeTranslateMath(englishStr2, template, locale);
+        assert.equal(output2, translatedStr2);
+
+    });
+
+    it('should only support coord/interval notation specific for given lang',
+    function() {
+        let locale = 'fr';
+        assert(!MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(locale));
+
+        const englishStr = '(a, b) (1,2)';
+        const translatedStr = englishStr;
+        let template = '[1,2]';
+        let output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+
+        locale = 'cs';
+        assert(!MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(locale));
+        template = ']1,2[';
+        output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+
+        locale = 'bg';
+        assert(!MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(locale));
+        template = '[1,2]';
+        output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+    });
+
+    it('should translate closed intervals without template', function() {
+        const locale = 'fr';
+        assert(MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(locale));
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(locale));
+
+        const englishStr = '[a,b] (c, d] (1,2)';
+        const template = null;
+        const translatedStr = '[a;b] ]c;d] ]1;2[';
+        const output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+    });
+
+    it('should support open intervals with inverted brackets', function() {
+        const locale = 'fr';
+        assert(MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(locale));
+
+        const englishStr = '(a, b) (1,2)';
+        const template = ']1,2[';
+        const translatedStr = ']a,b[ ]1,2[';
+        const output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+    });
+
+    it('should support additional space in separator', function() {
+        const locale = 'fr';
+        assert(!MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(locale));
+
+        const englishStr = '( 2,1)';
+        const template = '(3~; 4)';
+        const translatedStr = '(2~; 1)';
+        const output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+
+        const englishStr2 = '(1,2)';
+        const template2 = '(3\\,;4)';
+        const translatedStr2 = '(1\\,;2)';
+        const output2 = maybeTranslateMath(englishStr2, template2, locale);
+        assert.equal(output2, translatedStr2);
+    });
+});
+
+describe('detectClosedIntervals', function() {
+
+    it('should detect closed intervals with integers', function() {
+        let englishMath = '[12 , 200]';
+        assert(detectClosedInterval(englishMath));
+
+        // Testing negative integers
+        englishMath = '[-5,10]';
+        assert(detectClosedInterval(englishMath));
+    });
+
+    it('should detect closed intervals with variables', function() {
+        let englishMath = '[a,b]';
+        assert(detectClosedInterval(englishMath));
+
+        englishMath = '[1 ,b]';
+        assert(detectClosedInterval(englishMath));
+
+        englishMath = '[a, 2]';
+        assert(detectClosedInterval(englishMath));
+
+        englishMath = '[\\blue{a}, 2]';
+        assert(detectClosedInterval(englishMath));
+    });
+
+    it('should detect intervals with decimals', function() {
+        let englishMath = '[1,1.2]';
+        assert(detectClosedInterval(englishMath));
+
+        englishMath = '[\\red{1.2}, b]';
+        assert(detectClosedInterval(englishMath));
+
+        englishMath = '[\\blueD{1}.2 , a)';
+        assert(detectClosedInterval(englishMath));
+
+        englishMath = '[1, \\red{1}.\\overline{2}]';
+        assert(detectClosedInterval(englishMath));
+    });
+
+    it('should detect half closed intervals', function() {
+        let englishMath = '(a,b]';
+        assert(detectClosedInterval(englishMath));
+
+        englishMath = '[a,2)';
+        assert(detectClosedInterval(englishMath));
+    });
+});
+
+describe('detectCoordinates', function() {
+
+    it('should detect coordinates', function() {
+        let englishMath = '(4, 2.2)';
+        assert(detectCoordinates(englishMath));
+
+        englishMath = '(2, 3) (4,2)';
+        assert(detectCoordinates(englishMath));
+
+        englishMath = '(0,0)';
+        assert(detectCoordinates(englishMath));
+    });
+
+    it('should detect coordinates wrapped in color commands', function() {
+        let englishMath = '(\\redD{4}, -\\blueA{2})';
+        assert(detectCoordinates(englishMath));
+
+        englishMath = '(\\redD{4}, \\blueA{-2})';
+        assert(detectCoordinates(englishMath));
+
+        // https://crowdin.com/translate/khanacademy/26576/enus-lol#6546980
+        englishMath = '(\\goldE4,\\maroonD0)';
+        assert(detectCoordinates(englishMath));
+
+        englishMath = '( \\blueD3, \\greenD1 )';
+        assert(detectCoordinates(englishMath));
+    });
+
+    it('should detect coordinates with decimals', function() {
+        let englishMath = '(\\redD{4}.2, \\blueA{2}.\\kaGreen{0})';
+        assert(detectCoordinates(englishMath));
+
+        englishMath = '(\\redD{4.2}, \\blueA{-2.0})';
+        assert(detectCoordinates(englishMath));
+    });
+
+    it('should NOT detect coordinates that could also be open intervals',
+    function() {
+        let englishMath = '(2.1,4)';
+        assert(!detectCoordinates(englishMath));
+
+        englishMath = '(2,b)';
+        assert(!detectCoordinates(englishMath));
+
+        englishMath = '(a,b)';
+        assert(!detectCoordinates(englishMath));
+    });
 });
 
 describe('MATH_RULES_LOCALES', function() {
@@ -456,6 +732,12 @@ describe('MATH_RULES_LOCALES', function() {
 
         MATH_RULES_LOCALES.CSC_AS_COSSEC.forEach(function(locale) {
             assert(! MATH_RULES_LOCALES.CSC_AS_COSEC.includes(locale));
+        });
+    });
+
+    it('should not have conflicting rules for repeating decimals', function() {
+        MATH_RULES_LOCALES.OVERLINE_AS_DOT.forEach(function(locale) {
+            assert(! MATH_RULES_LOCALES.OVERLINE_AS_PARENS.includes(locale));
         });
     });
 });

--- a/tests/math_translator_spec.js
+++ b/tests/math_translator_spec.js
@@ -445,7 +445,7 @@ describe('MathTranslator (maybeTranslateMath)', function() {
     });
 
     it('should support semicolon as separator for all langs', function() {
-        const locale = 'cs';
+        const locale = 'pt';
         assert(!MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(locale));
 
         const englishStr = '[a, b] [1 ,d) (e , 2] (1,2)';
@@ -565,6 +565,20 @@ describe('MathTranslator (maybeTranslateMath)', function() {
         const englishStr = '(a, b) (1,2)';
         const template = ']1,2[';
         const translatedStr = ']a,b[ ]1,2[';
+        const output = maybeTranslateMath(englishStr, template, locale);
+        assert.equal(output, translatedStr);
+    });
+
+    it('should translate closed intervals with angle brackets', function() {
+        const locale = 'cs';
+        assert(
+            MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS.includes(locale)
+        );
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(locale));
+
+        const englishStr = '(a, b) [1,2) (1,2.1] [ \\red4, 5]';
+        const template = '';
+        const translatedStr = '(a;b) <1;2) (1;2.1> <\\red4;5>';
         const output = maybeTranslateMath(englishStr, template, locale);
         assert.equal(output, translatedStr);
     });
@@ -738,6 +752,14 @@ describe('MATH_RULES_LOCALES', function() {
     it('should not have conflicting rules for repeating decimals', function() {
         MATH_RULES_LOCALES.OVERLINE_AS_DOT.forEach(function(locale) {
             assert(! MATH_RULES_LOCALES.OVERLINE_AS_PARENS.includes(locale));
+        });
+    });
+
+    it('should not have conflicting rules for intervals', function() {
+        MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.forEach(function(locale) {
+            assert(
+            ! MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS.includes(locale)
+            );
         });
     });
 });


### PR DESCRIPTION
This change implements translation of notation for coordinates and intervals
(columns I,J,K from [this doc](https://docs.google.com/spreadsheets/d/1qgi-KjumcZ6yru19U5weqZK9TosRlTdLZqbXbABBJoQ/edit#gid))
There are couple things that make this change complex:
1. US coordinates and open intervals have the same notation.
2. Regexes to match coordinates/intervals need to account
   for a lot of variability and corner cases.

We assume that a single string will not mix intervals and coordinates
and use the following heuristic to distinguish them:
1. Try to find closed/half-closed intervals
2. If not found, try to detect coordinates
   (for details, see comment for detectCoordinates())
3. For certain strings such as (1,2), we cannot differentiate
   between coordinates and intervals so we will extract the notation
   from the translated template (if available).

Issue: https://khanacademy.atlassian.net/browse/CP-4001

Test Plan:
Test coordinates and intervals in following exercises:
https://www.khanacademy.org/translations/edit/cs/a/points-on-the-coordinate-plane/by-pattern
https://www.khanacademy.org/translations/edit/cs/e/graphing_points/tree/upstream/by-pattern
https://www.khanacademy.org/translations/edit/cs/e/identifying-points/tree/upstream/by-pattern
https://www.khanacademy.org/translations/edit/cs/e/extreme-value-theorem/tree/upstream/by-pattern
https://www.khanacademy.org/translations/edit/fr/a/graph-points-review