### PR TITLE
FIX: Repeating dec. dot notation with a period > 2 digits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-data
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Translation Assistant
 
-[![CI](https://github.com/Khan/translation-assistant/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/Khan/translation-assistant/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/Khan/translation-assistant/workflows/Node.js%20CI/badge.svg?branch=master&event=push)](https://github.com/Khan/translation-assistant/actions?query=workflow%3A%22Node.js+CI%22)
 
 Provides functions that analyze and suggest translations for similar strings
 based on an existing translation. Powers the Smart Translations feature in Khan
 Translation Editor.
+
+To ignore eslint style-guide commits in blame history, use:
+```sh
+git blame --ignore-revs-file .git-blame-ignore-revs
+```
+
+or to do it automatically:
+```sh
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```

--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -12,17 +12,19 @@
 
 var MATH_RULES_LOCALES = {
     // Number formats
-    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol', 'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
-    THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el', 'id'],
-    NO_THOUSAND_SEP: ['ko', 'ps', 'ka', 'hy'],
-    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol', 'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka', 'ru', 'ta', 'hy'],
+    THOUSAND_SEP_AS_THIN_SPACE: ['az', 'bg', 'cs', 'de', 'fr', 'hu', 'it', 'lv', 'nb', 'nl', 'pl', 'pt-pt', 'ro', 'sv', 'uk'],
+    THOUSAND_SEP_AS_DOT: ['da', 'el', 'id', 'pt', 'sr', 'tr'],
+    NO_THOUSAND_SEP: ['hy', 'ka', 'ko', 'ps'],
+    DECIMAL_COMMA: ['az', 'bg', 'cs', 'da', 'de', 'el', 'fr', 'hu', 'hy', 'id', 'it', 'ka', 'lv', 'nb', 'nl', 'pl', 'pt', 'pt-pt', 'ro', 'ru', 'sr', 'sv', 'tr'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],
-    // Notations for repeating decimals - 0.\overline{3}
-    // 0.\dot{3}
-    OVERLINE_AS_DOT: ['bn'],
-    // 0.(3)
-    OVERLINE_AS_PARENS: ['az', 'pt-pt', 'hy', 'pl'],
+    // Notations for repeating decimals
+    // 1 / 3 = 0.\overline{3} -> 0.\dot{3}
+    // 1 / 7 = 0.\overline{142857} -> 0.\dot{1}4285\dot{7}
+    OVERLINE_AS_DOT: ['bn', 'hu', 'ja'],
+    // 1 / 3 = 0.\overline{3} -> 0.(3)
+    // 1 / 7 = 0.\overline{142857} -> 0.(142857)
+    OVERLINE_AS_PARENS: ['az', 'bg', 'hy', 'lv', 'pl', 'pt-pt', 'ro'],
 
     // Intervals and cartesian coordinates
     // (a,b) - US open interval or coordinates
@@ -36,21 +38,21 @@ var MATH_RULES_LOCALES = {
     COORDS_AS_BRACKETS: ['cs'],
     // Binary operators
     // TODO(danielhollas):remove 'bg' from TIMES_AS_CDOT
-    // when \mathbin{.} becomes available for them
-    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'hy', 'sv', 'da', 'bg'],
-    CDOT_AS_TIMES: ['fr', 'ps', 'pt-pt', 'ta'],
-    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'pl', 'it', 'pt-pt', 'ru', 'nb'],
+    // when \mathbin{.} becomes available for them (currently blocked by linter)
+    TIMES_AS_CDOT: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'lv', 'nb', 'pl', 'ro', 'sr', 'sv'],
+    CDOT_AS_TIMES: ['fr', 'ps', 'pt-pt'],
+    DIV_AS_COLON: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'it', 'lv', 'nb', 'pl', 'pt-pt', 'ro', 'ru', 'uk'],
     // Trig functions
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
-    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'pt', 'pt-pt'],
+    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'lv', 'pt', 'pt-pt', 'ro'],
     COT_AS_COTG: ['cs', 'pt', 'pt-pt'],
-    COT_AS_CTG: ['az', 'hu', 'hy', 'bg'],
-    CSC_AS_COSEC: ['az', 'bg', 'bn', 'cs'],
+    COT_AS_CTG: ['az', 'bg', 'hu', 'hy', 'lv', 'ro'],
+    CSC_AS_COSEC: ['az', 'bg', 'bn', 'cs', 'gu', 'hi', 'kn', 'lv', 'my', 'pa', 'ro'],
     CSC_AS_COSSEC: ['pt', 'pt-pt'],
     // Rules conditional on the translated template
     MAYBE_DIV_AS_COLON: ['id', 'lol'],
-    MAYBE_TIMES_AS_CDOT: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka', 'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
-    MAYBE_CDOT_AS_TIMES: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka', 'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol']
+    MAYBE_TIMES_AS_CDOT: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kn', 'ko', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'uk', 'zh-hans'],
+    MAYBE_CDOT_AS_TIMES: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kn', 'ko', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'uk', 'zh-hans']
 };
 
 /**
@@ -141,11 +143,12 @@ function translateNumbers(math, lang) {
     { langs: MATH_RULES_LOCALES.ARABIC_COMMA,
         regex: decimalNumberRegex, replace: '$1{،}$2' },
 
-    // Different notations for repeating decimals
+    // Notations for repeating decimals
     { langs: MATH_RULES_LOCALES.OVERLINE_AS_PARENS,
-        regex: /\\overline\{(\d+)\}/g, replace: '($1)' },
-
-    // MATH_RULES_LOCALES.OVERLINE_AS_DOT needs special handling
+        regex: /\\overline\{(\d+)\}/g, replace: '($1)' }, { langs: MATH_RULES_LOCALES.OVERLINE_AS_DOT,
+        regex: /\\overline\{(\d)\}/g, replace: '\\dot{$1}' }, { langs: MATH_RULES_LOCALES.OVERLINE_AS_DOT,
+        regex: /\\overline\{(\d)(\d*)(\d)\}/g,
+        replace: '\\dot{$1}$2\\dot{$3}' },
 
     // Thousand separator notations
 
@@ -166,18 +169,6 @@ function translateNumbers(math, lang) {
             math = math.replace(element.regex, element.replace);
         }
     });
-
-    // Special handling for OVERLINE_AS_DOT rule for repeating decimals
-    // we need to translate 0.\overline{12} as 0.\dot{1}\dot{2}
-    if (MATH_RULES_LOCALES.OVERLINE_AS_DOT.includes(lang)) {
-        var fromRegex = new RegExp(/\\overline\{(\d+)\}/, 'g');
-        var match = undefined;
-        while ((match = fromRegex.exec(math)) !== null) {
-            var numbers = match[1];
-            var replace = numbers.replace(/\d/g, '\\dot{$&}');
-            math = math.replace(match[0], replace);
-        }
-    }
 
     return math;
 }

--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -12,10 +12,10 @@
 
 var MATH_RULES_LOCALES = {
     // Number formats
-    THOUSAND_SEP_AS_THIN_SPACE: ['az', 'bg', 'cs', 'de', 'fr', 'hu', 'it', 'lv', 'nb', 'nl', 'pl', 'pt-pt', 'ro', 'sv', 'uk'],
-    THOUSAND_SEP_AS_DOT: ['da', 'el', 'id', 'pt', 'sr', 'tr'],
-    NO_THOUSAND_SEP: ['hy', 'ka', 'ko', 'ps'],
-    DECIMAL_COMMA: ['az', 'bg', 'cs', 'da', 'de', 'el', 'fr', 'hu', 'hy', 'id', 'it', 'ka', 'lv', 'nb', 'nl', 'pl', 'pt', 'pt-pt', 'ro', 'ru', 'sr', 'sv', 'tr'],
+    THOUSAND_SEP_AS_THIN_SPACE: ['az', 'bg', 'cs', 'de', 'fr', 'hu', 'it', 'ka', 'km', 'ky', 'lv', 'nb', 'nl', 'pl', 'pt-pt', 'ro', 'sv', 'uk'],
+    THOUSAND_SEP_AS_DOT: ['da', 'el', 'id', 'pt', 'sr', 'tr', 'vi'],
+    NO_THOUSAND_SEP: ['hy', 'kk', 'ko', 'ps'],
+    DECIMAL_COMMA: ['az', 'bg', 'cs', 'da', 'de', 'el', 'fr', 'hu', 'hy', 'id', 'it', 'ka', 'kk', 'ky', 'lv', 'nb', 'nl', 'pl', 'pt', 'pt-pt', 'ro', 'ru', 'sr', 'sv', 'tr', 'vi'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],
     // Notations for repeating decimals
@@ -24,7 +24,7 @@ var MATH_RULES_LOCALES = {
     OVERLINE_AS_DOT: ['bn', 'hu', 'ja'],
     // 1 / 3 = 0.\overline{3} -> 0.(3)
     // 1 / 7 = 0.\overline{142857} -> 0.(142857)
-    OVERLINE_AS_PARENS: ['az', 'bg', 'hy', 'lv', 'pl', 'pt-pt', 'ro'],
+    OVERLINE_AS_PARENS: ['az', 'bg', 'hy', 'ka', 'kk', 'ky', 'lv', 'pl', 'pt-pt', 'ro', 'ru', 'vi'],
 
     // Intervals and cartesian coordinates
     // (a,b) - US open interval or coordinates
@@ -41,18 +41,18 @@ var MATH_RULES_LOCALES = {
     // when \mathbin{.} becomes available for them (currently blocked by linter)
     TIMES_AS_CDOT: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'lv', 'nb', 'pl', 'ro', 'sr', 'sv'],
     CDOT_AS_TIMES: ['fr', 'ps', 'pt-pt'],
-    DIV_AS_COLON: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'it', 'lv', 'nb', 'pl', 'pt-pt', 'ro', 'ru', 'uk'],
+    DIV_AS_COLON: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'it', 'ky', 'lv', 'nb', 'pl', 'pt-pt', 'ro', 'ru', 'sv', 'uk'],
     // Trig functions
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
-    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'lv', 'pt', 'pt-pt', 'ro'],
+    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'kk', 'km', 'ky', 'lv', 'pl', 'pt', 'pt-pt', 'ro', 'ru'],
     COT_AS_COTG: ['cs', 'pt', 'pt-pt'],
-    COT_AS_CTG: ['az', 'bg', 'hu', 'hy', 'lv', 'ro'],
-    CSC_AS_COSEC: ['az', 'bg', 'bn', 'cs', 'gu', 'hi', 'kn', 'lv', 'my', 'pa', 'ro'],
+    COT_AS_CTG: ['az', 'bg', 'hu', 'hy', 'kk', 'km', 'ky', 'lv', 'pl', 'ro', 'ru'],
+    CSC_AS_COSEC: ['as', 'az', 'bg', 'bn', 'cs', 'gu', 'hi', 'kn', 'ky', 'lv', 'mr', 'my', 'pa', 'pl', 'ro', 'ru', 'sv', 'ta', 'te'],
     CSC_AS_COSSEC: ['pt', 'pt-pt'],
     // Rules conditional on the translated template
     MAYBE_DIV_AS_COLON: ['id', 'lol'],
-    MAYBE_TIMES_AS_CDOT: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kn', 'ko', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'uk', 'zh-hans'],
-    MAYBE_CDOT_AS_TIMES: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kn', 'ko', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'uk', 'zh-hans']
+    MAYBE_TIMES_AS_CDOT: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kk', 'km', 'kn', 'ko', 'mr', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'th', 'uk', 'vi', 'zh-hans'],
+    MAYBE_CDOT_AS_TIMES: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kk', 'km', 'kn', 'ko', 'mr', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'th', 'uk', 'vi', 'zh-hans']
 };
 
 /**

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -49,7 +49,7 @@ var LINE_BREAK = '\n\n';
  * The `str` property is the `str` parameter with math, graphies, images, and
  * widgets replaced with placeholders.  Also, we remove unimportant whitespace
  * differences on the item so that we can group strings with similar natural
- * language text.  We also disregard bold markup when determining a match.
+ * language text. We also disregard bold markup when determining a match.
  * This means that translators may have to add bold markup to the suggestion
  * in some cases.
  *
@@ -112,7 +112,7 @@ function stringToGroupKey(str) {
  *
  * This mapping array indicates that the first two __MATH__ placeholders in the
  * translated string template should be replaced with the second formula
- * from the English string we're translating.  The third __MATH__ placeholder
+ * from the English string we're translating. The third __MATH__ placeholder
  * should be replaced by the first formula from the English string we're
  * translating.
  *
@@ -178,7 +178,7 @@ mathDictionary) {
 }
 
 /**
- * Helper for getting all subgroup matches from a string.  The callback is
+ * Helper for getting all subgroup matches from a string. The callback is
  * passed the matches array for each match in `text`.
  *
  * @param {String} text The string to find matches in.
@@ -331,8 +331,8 @@ function getMathDictionary(englishStr, translatedStr, lang) {
  * Creates a template object based on englishStr and translatedStr strings.
  *
  * All math, graphie, and widget sub-strings are replaced by placeholders and
- * the mappings for which sub-string goes where in the translatedStr.  The
- * englishStr is split into lines.  While this isn't particular useful right
+ * the mappings for which sub-string goes where in the translatedStr. The
+ * englishStr is split into lines. While this isn't particular useful right
  * now, the plan is to eventually use the lines creating suggestions for
  * partial matches.
  *
@@ -399,7 +399,7 @@ function escapeForRegex(str) {
 /**
  * Translate the text inside \\text{} and \\textbf blocks.
  *
- * @param {string} englishMath The math string to translate.  If a English
+ * @param {string} englishMath The math string to translate. If an English
  *      string from CrowdIn is "Solve $3\\text{nickles} = x\\textbf{pennies}$"
  *      then englishMath would be "3\\text{nickles} = x\\textbf{pennies}"
  * @param {Object} dict A mapping from english words to translated words that
@@ -649,12 +649,12 @@ var TranslationAssistant = (function () {
      * Group objects that contain English strings to translate.
      *
      * Groups are determined by the similarity between the English strings
-     * returned by `this.getEnglishStr` on each object in `items`.  In order to
+     * returned by `this.getEnglishStr` on each object in `items`. In order to
      * find more matches we ignore math, graphie, and widget substrings.
      *
      * Each group contains an array of items that belong in that group and a
      * translation template if there was at least one item that had a
-     * translation.  Translations are determined by passing each item to
+     * translation. Translations are determined by passing each item to
      * `this.getTranslation`.
      *
      * Input:

--- a/src/math-translator.js
+++ b/src/math-translator.js
@@ -10,20 +10,22 @@
  */
 const MATH_RULES_LOCALES = {
     // Number formats
-    THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol',
-        'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
-    THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el', 'id'],
-    NO_THOUSAND_SEP: ['ko', 'ps', 'ka', 'hy'],
-    DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol',
-        'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka',
-        'ru', 'ta', 'hy'],
+    THOUSAND_SEP_AS_THIN_SPACE: ['az', 'bg', 'cs', 'de', 'fr', 'hu', 'it',
+        'lv', 'nb', 'nl', 'pl', 'pt-pt', 'ro', 'sv', 'uk'],
+    THOUSAND_SEP_AS_DOT: ['da', 'el', 'id', 'pt', 'sr', 'tr' ],
+    NO_THOUSAND_SEP: ['hy', 'ka', 'ko', 'ps' ],
+    DECIMAL_COMMA: ['az', 'bg', 'cs', 'da', 'de', 'el', 'fr', 'hu', 'hy', 'id',
+        'it', 'ka', 'lv', 'nb', 'nl', 'pl', 'pt', 'pt-pt', 'ro', 'ru', 'sr',
+        'sv', 'tr'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],
-    // Notations for repeating decimals - 0.\overline{3}
-    // 0.\dot{3}
-    OVERLINE_AS_DOT: ['bn'],
-    // 0.(3)
-    OVERLINE_AS_PARENS: ['az', 'pt-pt', 'hy', 'pl'],
+    // Notations for repeating decimals
+    // 1 / 3 = 0.\overline{3} -> 0.\dot{3}
+    // 1 / 7 = 0.\overline{142857} -> 0.\dot{1}4285\dot{7}
+    OVERLINE_AS_DOT: ['bn', 'hu', 'ja'],
+    // 1 / 3 = 0.\overline{3} -> 0.(3)
+    // 1 / 7 = 0.\overline{142857} -> 0.(142857)
+    OVERLINE_AS_PARENS: ['az', 'bg', 'hy', 'lv', 'pl', 'pt-pt', 'ro'],
 
     // Intervals and cartesian coordinates
     // (a,b) - US open interval or coordinates
@@ -37,25 +39,26 @@ const MATH_RULES_LOCALES = {
     COORDS_AS_BRACKETS: ['cs'],
     // Binary operators
     // TODO(danielhollas):remove 'bg' from TIMES_AS_CDOT
-    // when \mathbin{.} becomes available for them
-    TIMES_AS_CDOT: ['cs', 'pl', 'de', 'nb', 'sr', 'ro', 'hu', 'hy', 'sv',
-        'da', 'bg'],
-    CDOT_AS_TIMES: ['fr', 'ps', 'pt-pt', 'ta'],
-    DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'pl', 'it',
-        'pt-pt', 'ru', 'nb'],
+    // when \mathbin{.} becomes available for them (currently blocked by linter)
+    TIMES_AS_CDOT: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'lv', 'nb', 'pl',
+        'ro', 'sr', 'sv' ],
+    CDOT_AS_TIMES: [ 'fr', 'ps', 'pt-pt'],
+    DIV_AS_COLON: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'it', 'lv', 'nb',
+        'pl', 'pt-pt', 'ro', 'ru', 'uk'],
     // Trig functions
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
-    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'pt', 'pt-pt'],
+    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'lv', 'pt', 'pt-pt', 'ro'],
     COT_AS_COTG: ['cs', 'pt', 'pt-pt'],
-    COT_AS_CTG: ['az', 'hu', 'hy', 'bg'],
-    CSC_AS_COSEC: ['az', 'bg', 'bn', 'cs'],
+    COT_AS_CTG: ['az', 'bg', 'hu', 'hy', 'lv', 'ro'],
+    CSC_AS_COSEC: ['az', 'bg', 'bn', 'cs', 'gu', 'hi', 'kn', 'lv', 'my', 'pa',
+        'ro'],
     CSC_AS_COSSEC: ['pt', 'pt-pt'],
     // Rules conditional on the translated template
     MAYBE_DIV_AS_COLON: ['id', 'lol'],
-    MAYBE_TIMES_AS_CDOT: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka',
-        'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
-    MAYBE_CDOT_AS_TIMES: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka',
-        'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
+    MAYBE_TIMES_AS_CDOT: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kn',
+        'ko', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'uk', 'zh-hans'],
+    MAYBE_CDOT_AS_TIMES: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kn',
+        'ko', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'uk', 'zh-hans'],
 };
 
 
@@ -160,11 +163,16 @@ function translateNumbers(math, lang) {
         {langs: MATH_RULES_LOCALES.ARABIC_COMMA,
             regex: decimalNumberRegex, replace: '$1{،}$2'},
 
-        // Different notations for repeating decimals
+        // Notations for repeating decimals
         {langs: MATH_RULES_LOCALES.OVERLINE_AS_PARENS,
             regex: /\\overline\{(\d+)\}/g, replace: '($1)'},
 
-        // MATH_RULES_LOCALES.OVERLINE_AS_DOT needs special handling
+        {langs: MATH_RULES_LOCALES.OVERLINE_AS_DOT,
+            regex: /\\overline\{(\d)\}/g, replace: '\\dot{$1}'},
+
+        {langs: MATH_RULES_LOCALES.OVERLINE_AS_DOT,
+            regex: /\\overline\{(\d)(\d*)(\d)\}/g,
+            replace: '\\dot{$1}$2\\dot{$3}'},
 
         // Thousand separator notations
 
@@ -186,18 +194,6 @@ function translateNumbers(math, lang) {
             math = math.replace(element.regex, element.replace);
         }
     });
-
-    // Special handling for OVERLINE_AS_DOT rule for repeating decimals
-    // we need to translate 0.\overline{12} as 0.\dot{1}\dot{2}
-    if (MATH_RULES_LOCALES.OVERLINE_AS_DOT.includes(lang)) {
-        const fromRegex = new RegExp(/\\overline\{(\d+)\}/, 'g');
-        let match;
-        while ((match = fromRegex.exec(math)) !== null) {
-            const numbers = match[1];
-            const replace = numbers.replace(/\d/g, '\\dot{$&}');
-            math = math.replace(match[0], replace);
-        }
-    }
 
     return math;
 }

--- a/src/math-translator.js
+++ b/src/math-translator.js
@@ -10,13 +10,13 @@
  */
 const MATH_RULES_LOCALES = {
     // Number formats
-    THOUSAND_SEP_AS_THIN_SPACE: ['az', 'bg', 'cs', 'de', 'fr', 'hu', 'it',
-        'lv', 'nb', 'nl', 'pl', 'pt-pt', 'ro', 'sv', 'uk'],
-    THOUSAND_SEP_AS_DOT: ['da', 'el', 'id', 'pt', 'sr', 'tr' ],
-    NO_THOUSAND_SEP: ['hy', 'ka', 'ko', 'ps' ],
+    THOUSAND_SEP_AS_THIN_SPACE: ['az', 'bg', 'cs', 'de', 'fr', 'hu', 'it', 'ka',
+        'km', 'ky', 'lv', 'nb', 'nl', 'pl', 'pt-pt', 'ro', 'sv', 'uk'],
+    THOUSAND_SEP_AS_DOT: ['da', 'el', 'id', 'pt', 'sr', 'tr', 'vi'],
+    NO_THOUSAND_SEP: ['hy', 'kk', 'ko', 'ps' ],
     DECIMAL_COMMA: ['az', 'bg', 'cs', 'da', 'de', 'el', 'fr', 'hu', 'hy', 'id',
-        'it', 'ka', 'lv', 'nb', 'nl', 'pl', 'pt', 'pt-pt', 'ro', 'ru', 'sr',
-        'sv', 'tr'],
+        'it', 'ka', 'kk', 'ky', 'lv', 'nb', 'nl', 'pl', 'pt', 'pt-pt', 'ro',
+        'ru', 'sr', 'sv', 'tr', 'vi'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],
     // Notations for repeating decimals
@@ -25,7 +25,8 @@ const MATH_RULES_LOCALES = {
     OVERLINE_AS_DOT: ['bn', 'hu', 'ja'],
     // 1 / 3 = 0.\overline{3} -> 0.(3)
     // 1 / 7 = 0.\overline{142857} -> 0.(142857)
-    OVERLINE_AS_PARENS: ['az', 'bg', 'hy', 'lv', 'pl', 'pt-pt', 'ro'],
+    OVERLINE_AS_PARENS: ['az', 'bg', 'hy', 'ka', 'kk', 'ky', 'lv', 'pl',
+        'pt-pt', 'ro', 'ru', 'vi'],
 
     // Intervals and cartesian coordinates
     // (a,b) - US open interval or coordinates
@@ -43,22 +44,26 @@ const MATH_RULES_LOCALES = {
     TIMES_AS_CDOT: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'lv', 'nb', 'pl',
         'ro', 'sr', 'sv' ],
     CDOT_AS_TIMES: [ 'fr', 'ps', 'pt-pt'],
-    DIV_AS_COLON: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'it', 'lv', 'nb',
-        'pl', 'pt-pt', 'ro', 'ru', 'uk'],
+    DIV_AS_COLON: ['az', 'bg', 'cs', 'da', 'de', 'hu', 'hy', 'it', 'ky', 'lv',
+        'nb', 'pl', 'pt-pt', 'ro', 'ru', 'sv', 'uk'],
     // Trig functions
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
-    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'lv', 'pt', 'pt-pt', 'ro'],
+    TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'kk', 'km', 'ky', 'lv', 'pl',
+        'pt', 'pt-pt', 'ro', 'ru'],
     COT_AS_COTG: ['cs', 'pt', 'pt-pt'],
-    COT_AS_CTG: ['az', 'bg', 'hu', 'hy', 'lv', 'ro'],
-    CSC_AS_COSEC: ['az', 'bg', 'bn', 'cs', 'gu', 'hi', 'kn', 'lv', 'my', 'pa',
-        'ro'],
+    COT_AS_CTG: ['az', 'bg', 'hu', 'hy', 'kk', 'km', 'ky', 'lv', 'pl', 'ro',
+        'ru'],
+    CSC_AS_COSEC: ['as', 'az', 'bg', 'bn', 'cs', 'gu', 'hi', 'kn', 'ky', 'lv',
+        'mr', 'my', 'pa', 'pl', 'ro', 'ru', 'sv', 'ta', 'te'],
     CSC_AS_COSSEC: ['pt', 'pt-pt'],
     // Rules conditional on the translated template
     MAYBE_DIV_AS_COLON: ['id', 'lol'],
-    MAYBE_TIMES_AS_CDOT: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kn',
-        'ko', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'uk', 'zh-hans'],
-    MAYBE_CDOT_AS_TIMES: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kn',
-        'ko', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'uk', 'zh-hans'],
+    MAYBE_TIMES_AS_CDOT: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kk',
+        'km', 'kn', 'ko', 'mr', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'th',
+        'uk', 'vi', 'zh-hans'],
+    MAYBE_CDOT_AS_TIMES: ['bn', 'el', 'gu', 'hi', 'id', 'it', 'ja', 'ka', 'kk',
+        'km', 'kn', 'ko', 'mr', 'my', 'nl', 'pa', 'pt', 'ru', 'ta', 'te', 'th',
+        'uk', 'vi', 'zh-hans'],
 };
 
 

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -46,7 +46,7 @@ const LINE_BREAK = '\n\n';
  * The `str` property is the `str` parameter with math, graphies, images, and
  * widgets replaced with placeholders.  Also, we remove unimportant whitespace
  * differences on the item so that we can group strings with similar natural
- * language text.  We also disregard bold markup when determining a match.
+ * language text. We also disregard bold markup when determining a match.
  * This means that translators may have to add bold markup to the suggestion
  * in some cases.
  *
@@ -113,7 +113,7 @@ function stringToGroupKey(str) {
  *
  * This mapping array indicates that the first two __MATH__ placeholders in the
  * translated string template should be replaced with the second formula
- * from the English string we're translating.  The third __MATH__ placeholder
+ * from the English string we're translating. The third __MATH__ placeholder
  * should be replaced by the first formula from the English string we're
  * translating.
  *
@@ -181,7 +181,7 @@ function getMapping(
 }
 
 /**
- * Helper for getting all subgroup matches from a string.  The callback is
+ * Helper for getting all subgroup matches from a string. The callback is
  * passed the matches array for each match in `text`.
  *
  * @param {String} text The string to find matches in.
@@ -322,8 +322,8 @@ function getMathDictionary(englishStr, translatedStr, lang) {
  * Creates a template object based on englishStr and translatedStr strings.
  *
  * All math, graphie, and widget sub-strings are replaced by placeholders and
- * the mappings for which sub-string goes where in the translatedStr.  The
- * englishStr is split into lines.  While this isn't particular useful right
+ * the mappings for which sub-string goes where in the translatedStr. The
+ * englishStr is split into lines. While this isn't particular useful right
  * now, the plan is to eventually use the lines creating suggestions for
  * partial matches.
  *
@@ -400,7 +400,7 @@ function escapeForRegex(str) {
 /**
  * Translate the text inside \\text{} and \\textbf blocks.
  *
- * @param {string} englishMath The math string to translate.  If a English
+ * @param {string} englishMath The math string to translate. If an English
  *      string from CrowdIn is "Solve $3\\text{nickles} = x\\textbf{pennies}$"
  *      then englishMath would be "3\\text{nickles} = x\\textbf{pennies}"
  * @param {Object} dict A mapping from english words to translated words that
@@ -631,12 +631,12 @@ class TranslationAssistant {
      * Group objects that contain English strings to translate.
      *
      * Groups are determined by the similarity between the English strings
-     * returned by `this.getEnglishStr` on each object in `items`.  In order to
+     * returned by `this.getEnglishStr` on each object in `items`. In order to
      * find more matches we ignore math, graphie, and widget substrings.
      *
      * Each group contains an array of items that belong in that group and a
      * translation template if there was at least one item that had a
-     * translation.  Translations are determined by passing each item to
+     * translation. Translations are determined by passing each item to
      * `this.getTranslation`.
      *
      * Input:

--- a/tests/math_translator_spec.js
+++ b/tests/math_translator_spec.js
@@ -195,11 +195,14 @@ describe('MathTranslator (translateMath)', function() {
             const locale = 'bn';
             assert(MATH_RULES_LOCALES.OVERLINE_AS_DOT.includes(locale));
 
-            const englishStr = '1.\\overline{3} + 9.\\overline{44}';
-            const translatedStr = '1.\\dot{3} + 9.\\dot{4}\\dot{4}';
+            const englishStr =
+                '1.\\overline{3} + 9.\\overline{12} - 0.\\overline{123}';
+            const translatedStr =
+                '1.\\dot{3} + 9.\\dot{1}\\dot{2} - 0.\\dot{1}2\\dot{3}';
             const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
-        });
+        }
+    );
 
     it('should translate \\overline in repeating decimals as parentheses',
         function() {
@@ -714,6 +717,15 @@ describe('detectCoordinates', function() {
 });
 
 describe('MATH_RULES_LOCALES', function() {
+
+    it('should be sorted alphabetically', function() {
+        for (const locales of Object.values(MATH_RULES_LOCALES)) {
+            for (let i = 0; i < locales.length - 1; i++) {
+                // This also ensures that we don't have duplicates
+                assert(locales[i] < locales[i + 1]);
+            }
+        }
+    });
 
     it('should not have conflicting rules for multiplication', function() {
         MATH_RULES_LOCALES.CDOT_AS_TIMES.forEach(function(locale) {


### PR DESCRIPTION
**Summary**
I misunderstood how the dot notation for repeating decimals works.
This PR fixes a case of repeating decimals
with a period that is longer than two digits.
Incidentally, this made the code simpler. :-)

For example:
1 / 7 = 0.\overline{142857} -> 1.\dot{1}4285\dot{7}

I also alphabetically sorted all locale arrays
and added few locales based on the latest input from Advocates.

Issue: https://khanacademy.atlassian.net/browse/CP-3984

**Test Plan:**
 - Open this exercise for Hungarian and verify that
   repeating decimals are translated correctly.
https://www.khanacademy.org/translations/edit/hu/e/converting_fractions_to_decimals/tree/upstream/by-pattern

 - Specifically, this string
   https://crowdin.com/translate/khanacademy/26308/enus-hu#5315597
   should be autotranslated as:
   '$4{,}1\\dot{6}6\dot{7}$'