### PR TITLE
Bump Eslint version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,7 @@
         "require-jsdoc": 1,
         "space-before-blocks": 2,
         "space-infix-ops": 2,
-        "space-return-throw-case": 2,
+        "keyword-spacing": 2,
         "no-trailing-spaces": 2,
         "max-len": [2, 80, 4, { "ignoreUrls": true, "ignorePattern": "^\\s*const\\s.+=\\s*require\\s*\\(" }],
         "guard-for-in": 2,

--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -14,16 +14,16 @@ var normalizeTranslatedMath = _require.normalizeTranslatedMath;
 // Matches math delimited by $, e.g.
 // $x^2 + 2x + 1 = 0$
 // $\text{cost} = \$4$
-var MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
+var MATH_REGEX = /\$(\\\$|[^$])+\$/g;
 
 // Matches graphie strings,
 // e.g. ![](web+graphie://ka-perseus-graphie.s3.amazonaws.com/542f2b4e297910eed545a5c29c3866918655bab4)
-var GRAPHIE_REGEX = /\!\[\]\([^)]+\)/g;
+var GRAPHIE_REGEX = /!\[\]\([^)]+\)/g;
 
 // Matches pure image and graphie link strings,
 // e.g. https://ka-perseus-graphie.s3.amazonaws.com/e75c49cb5753492629016169933ab63af3b9f122.png
 // or web+graphie://ka-perseus-graphie.s3.amazonaws.com/542f2b4e297910eed545a5c29c3866918655bab4
-var IMAGE_REGEX = /https:[^\s]+\.png|web\+graphie:[a-z0-9\.\-/]+(?=[\s,]|$)/g;
+var IMAGE_REGEX = /https:[^\s]+\.png|web\+graphie:[a-z0-9.\-/]+(?=[\s,]|$)/g;
 
 // Matches widget strings, e.g. [[☃ Expression 1]]
 var WIDGET_REGEX = /\[\[[\u2603][^\]]+\]\]/g;
@@ -284,7 +284,7 @@ function getMathDictionary(englishStr, translatedStr, lang) {
                 var _ret2 = (function () {
                     var input = inputMap[key];
 
-                    if (!outputMap.hasOwnProperty(key)) {
+                    if (!Object.prototype.hasOwnProperty.call(outputMap, key)) {
                         // If outputMap is missing a key that exists in inputMap it
                         // means that the math differs between the input and output
                         // and getMapping will throw and error in that case.
@@ -393,7 +393,7 @@ function rtrim(str) {
  * @returns {String} The string with escaped characters
  */
 function escapeForRegex(str) {
-    return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    return str.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
 /**
@@ -477,8 +477,8 @@ function populateTemplate(template, englishStr, lang) {
         try {
             englishMapping = getMapping(englishStr, englishStr, 'en', MATH_REGEX, englishDictionary);
         } catch (error) {
-            console.error( // eslint-disable-line no-console
-            'Unexpected error in TranslationAssistant.populateTemplate');
+            // eslint-disable-next-line no-console
+            console.error('Unexpected error in TranslationAssistant.populateTemplate');
             return undefined;
         }
         // And verify that the math mapping is identical to the one in the
@@ -615,7 +615,7 @@ var TranslationAssistant = (function () {
                 return [item, englishStr];
             }
 
-            if (suggestionGroups.hasOwnProperty(normalStr)) {
+            if (Object.prototype.hasOwnProperty.call(suggestionGroups, normalStr)) {
                 var template = suggestionGroups[normalStr].template;
 
                 // This error is probably due to math being different between

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",
-    "eslint": "^7.5.0",
+    "eslint": "^7.7.0",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.3",
     "pre-commit": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",
-    "eslint": "^1.5.1",
+    "eslint": "^7.5.0",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.3",
     "pre-commit": "^1.2.2"

--- a/src/math-translator.js
+++ b/src/math-translator.js
@@ -11,12 +11,12 @@
 const MATH_RULES_LOCALES = {
     // Number formats
     THOUSAND_SEP_AS_THIN_SPACE: ['cs', 'fr', 'de', 'lol',
-         'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
+        'pt-pt', 'nb', 'bg', 'pl', 'ro', 'nl', 'az', 'sv', 'it', 'hu', 'uk'],
     THOUSAND_SEP_AS_DOT: ['pt', 'tr', 'da', 'sr', 'el', 'id'],
     NO_THOUSAND_SEP: ['ko', 'ps', 'ka', 'hy'],
     DECIMAL_COMMA: ['cs', 'fr', 'de', 'pl', 'bg', 'nb', 'tr', 'da', 'sr', 'lol',
-            'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka',
-            'ru', 'ta', 'hy'],
+        'ro', 'nl', 'hu', 'az', 'it', 'pt', 'pt-pt', 'sv', 'el', 'id', 'ka',
+        'ru', 'ta', 'hy'],
     ARABIC_COMMA: ['ps'],
     PERSO_ARABIC_NUMERALS: ['ps'],
     // Notations for repeating decimals - 0.\overline{3}
@@ -42,7 +42,7 @@ const MATH_RULES_LOCALES = {
         'da', 'bg'],
     CDOT_AS_TIMES: ['fr', 'ps', 'pt-pt', 'ta'],
     DIV_AS_COLON: ['cs', 'de', 'bg', 'hu', 'uk', 'da', 'hy', 'pl', 'it',
-            'pt-pt', 'ru', 'nb'],
+        'pt-pt', 'ru', 'nb'],
     // Trig functions
     SIN_AS_SEN: ['it', 'pt', 'pt-pt'],
     TAN_AS_TG: ['az', 'bg', 'cs', 'hu', 'hy', 'pt', 'pt-pt'],
@@ -53,9 +53,9 @@ const MATH_RULES_LOCALES = {
     // Rules conditional on the translated template
     MAYBE_DIV_AS_COLON: ['id', 'lol'],
     MAYBE_TIMES_AS_CDOT: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka',
-            'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
+        'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
     MAYBE_CDOT_AS_TIMES: ['az', 'bn', 'el', 'hi', 'id', 'it', 'ja', 'ka',
-            'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
+        'ko', 'nl', 'pt', 'ru', 'uk', 'zh-hans', 'lol'],
 };
 
 
@@ -101,15 +101,15 @@ function translateNumerals(math, lang) {
     // Perso-Arabic numerals (Used by Pashto)
     if (MATH_RULES_LOCALES.PERSO_ARABIC_NUMERALS.includes(lang)) {
         math = math.replace(/1/g, '۱')
-                   .replace(/2/g, '۲')
-                   .replace(/3/g, '۳')
-                   .replace(/4/g, '۴')
-                   .replace(/5/g, '۵')
-                   .replace(/6/g, '۶')
-                   .replace(/7/g, '۷')
-                   .replace(/8/g, '۸')
-                   .replace(/9/g, '۹')
-                   .replace(/0/g, '۰');
+            .replace(/2/g, '۲')
+            .replace(/3/g, '۳')
+            .replace(/4/g, '۴')
+            .replace(/5/g, '۵')
+            .replace(/6/g, '۶')
+            .replace(/7/g, '۷')
+            .replace(/8/g, '۸')
+            .replace(/9/g, '۹')
+            .replace(/0/g, '۰');
     }
     // TODO(danielhollas): Implement Eastern-Arabic numerals
     // (currently not in use by any team)
@@ -136,48 +136,48 @@ function translateNumbers(math, lang) {
     const thousandSeparatorRegex =
         new RegExp(`([0-9])${placeholder}([0-9])(?=[0-9]{2})`, 'g');
     const thousandSeparatorLocales = [].concat(
-            MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
-            MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
-            MATH_RULES_LOCALES.NO_THOUSAND_SEP);
+        MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
+        MATH_RULES_LOCALES.NO_THOUSAND_SEP);
 
     const decimalNumberRegex = new RegExp(getDecNumberRegexString('en'), 'g');
 
     const mathTranslations = [
-         // IMPORTANT NOTE: This MUST be the first regex
-         // Convert thousand separators to a placeholder
-         // to prevent interactions with decimal commas
-         {langs: thousandSeparatorLocales,
+        // IMPORTANT NOTE: This MUST be the first regex
+        // Convert thousand separators to a placeholder
+        // to prevent interactions with decimal commas
+        {langs: thousandSeparatorLocales,
             regex: /([0-9])\{,\}([0-9])(?=[0-9]{2})/g,
             replace: `$1${placeholder}$2`},
 
-         // Decimal comma
-         {langs: MATH_RULES_LOCALES.DECIMAL_COMMA,
+        // Decimal comma
+        {langs: MATH_RULES_LOCALES.DECIMAL_COMMA,
             regex: decimalNumberRegex, replace: '$1{,}$2'},
 
-         // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
-         // NOTE: At least in MathJax, this comma does not need braces,
-         // but it feels safer to have them here.
-         {langs: MATH_RULES_LOCALES.ARABIC_COMMA,
+        // Arabic decimal comma, see https://en.wikipedia.org/wiki/Comma
+        // NOTE: At least in MathJax, this comma does not need braces,
+        // but it feels safer to have them here.
+        {langs: MATH_RULES_LOCALES.ARABIC_COMMA,
             regex: decimalNumberRegex, replace: '$1{،}$2'},
 
-         // Different notations for repeating decimals
-         {langs: MATH_RULES_LOCALES.OVERLINE_AS_PARENS,
+        // Different notations for repeating decimals
+        {langs: MATH_RULES_LOCALES.OVERLINE_AS_PARENS,
             regex: /\\overline\{(\d+)\}/g, replace: '($1)'},
 
-         // MATH_RULES_LOCALES.OVERLINE_AS_DOT needs special handling
+        // MATH_RULES_LOCALES.OVERLINE_AS_DOT needs special handling
 
-         // Thousand separator notations
+        // Thousand separator notations
 
-         // No thousand separator
-         {langs: MATH_RULES_LOCALES.NO_THOUSAND_SEP,
+        // No thousand separator
+        {langs: MATH_RULES_LOCALES.NO_THOUSAND_SEP,
             regex: thousandSeparatorRegex, replace: '$1$2'},
 
-         // Thousand separator as a dot
-         {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
+        // Thousand separator as a dot
+        {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
             regex: thousandSeparatorRegex, replace: '$1.$2'},
 
-         // Thousand separator as a thin space (\, in Tex)
-         {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        // Thousand separator as a thin space (\, in Tex)
+        {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
             regex: thousandSeparatorRegex, replace: '$1\\,$2'},
     ];
 
@@ -213,45 +213,45 @@ function translateNumbers(math, lang) {
 function translateMathOperators(math, lang) {
 
     const mathTranslations = [
-         // BINARY OPERATORS
-         // division sign as a colon
-         {langs: MATH_RULES_LOCALES.DIV_AS_COLON,
+        // BINARY OPERATORS
+        // division sign as a colon
+        {langs: MATH_RULES_LOCALES.DIV_AS_COLON,
             regex: /\\div/g, replace: '\\mathbin{:}'},
 
-         // multiplication sign as a centered dot
-         {langs: MATH_RULES_LOCALES.TIMES_AS_CDOT,
+        // multiplication sign as a centered dot
+        {langs: MATH_RULES_LOCALES.TIMES_AS_CDOT,
             regex: /\\times/g, replace: '\\cdot'},
 
-         // multiplication sign as x
-         {langs: MATH_RULES_LOCALES.CDOT_AS_TIMES,
+        // multiplication sign as x
+        {langs: MATH_RULES_LOCALES.CDOT_AS_TIMES,
             regex: /\\cdot/g, replace: '\\times'},
 
-         // multiplication sign as a simple dot, a Bulgarian specialty
-         // TODO(danielhollas): not yet allowed by the linter
-         // TODO(danielhollas): add a test for this case
-         //{langs: ['bg'],
-         //   regex: /\\times/g, replace: '\\mathbin{.}'},
+        // multiplication sign as a simple dot, a Bulgarian specialty
+        // TODO(danielhollas): not yet allowed by the linter
+        // TODO(danielhollas): add a test for this case
+        //{langs: ['bg'],
+        //   regex: /\\times/g, replace: '\\mathbin{.}'},
 
-         // TRIG FUNCTIONS
-         // NOTE(danielhollas): In principle, some might want to use
-         // e.g. sin^{-1} instead of arcsin, but we'll keep it simple
-         // and that notation is confusing anyway (1/sin or arcsin?)
-         {langs: MATH_RULES_LOCALES.SIN_AS_SEN,
+        // TRIG FUNCTIONS
+        // NOTE(danielhollas): In principle, some might want to use
+        // e.g. sin^{-1} instead of arcsin, but we'll keep it simple
+        // and that notation is confusing anyway (1/sin or arcsin?)
+        {langs: MATH_RULES_LOCALES.SIN_AS_SEN,
             regex: /\\(arc)?sin/g, replace: '\\operatorname{$1sen}'},
 
-         {langs: MATH_RULES_LOCALES.TAN_AS_TG,
+        {langs: MATH_RULES_LOCALES.TAN_AS_TG,
             regex: /\\(arc)?tan/g, replace: '\\operatorname{$1tg}'},
 
-         {langs: MATH_RULES_LOCALES.COT_AS_COTG,
+        {langs: MATH_RULES_LOCALES.COT_AS_COTG,
             regex: /\\(arc)?cot/g, replace: '\\operatorname{$1cotg}'},
 
-         {langs: MATH_RULES_LOCALES.COT_AS_CTG,
+        {langs: MATH_RULES_LOCALES.COT_AS_CTG,
             regex: /\\(arc)?cot/g, replace: '\\operatorname{$1ctg}'},
 
-         {langs: MATH_RULES_LOCALES.CSC_AS_COSEC,
+        {langs: MATH_RULES_LOCALES.CSC_AS_COSEC,
             regex: /\\(arc)?csc/g, replace: '\\operatorname{$1cosec}'},
 
-         {langs: MATH_RULES_LOCALES.CSC_AS_COSSEC,
+        {langs: MATH_RULES_LOCALES.CSC_AS_COSSEC,
             regex: /\\(arc)?csc/g, replace: '\\operatorname{$1cossec}'},
     ];
 
@@ -280,39 +280,39 @@ function normalizeTranslatedMath(math, lang) {
     if (lang === 'en') return math;
 
     const mathNormalizations = [
-         // Strip superfluous curly braces around \\,
-         // which is used as thousand separator in some locales
-         // i.e. 10{,}200 can be translated as 10{\\,}200, but the curly
-         // braces are not really needed.
-         // To understand why braces are needed around comma, see:
-         // https://tex.stackexchange.com/questions/303110/avoid-space-after-thousands-separator-in-math-mode#303127
-         {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        // Strip superfluous curly braces around \\,
+        // which is used as thousand separator in some locales
+        // i.e. 10{,}200 can be translated as 10{\\,}200, but the curly
+        // braces are not really needed.
+        // To understand why braces are needed around comma, see:
+        // https://tex.stackexchange.com/questions/303110/avoid-space-after-thousands-separator-in-math-mode#303127
+        {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
             regex: /([0-9])\{\\,\}([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2'},
 
-         // Strip extra braces around a dot as a thousand separator
-         {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
+        // Strip extra braces around a dot as a thousand separator
+        {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT,
             regex: /([0-9])\{\.\}([0-9])(?=[0-9]{2})/g, replace: '$1.$2'},
 
-         // Allow translators to use a full space (~ in LaTeX)
-         // (but TA will always suggest thin space \,)
-         // We cannot allow a literal space here, cause Tex would ignore it
-         {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
+        // Allow translators to use a full space (~ in LaTeX)
+        // (but TA will always suggest thin space \,)
+        // We cannot allow a literal space here, cause Tex would ignore it
+        {langs: MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE,
             regex: /([0-9])\{?~\}?([0-9])(?=[0-9]{2})/g, replace: '$1\\,$2'},
 
-         // KaTeX supports more trig functions then default LaTeX
-         // (\tg, \arctg, \cotg \ctg, \cosec)
-         // but we're using \operatorname for them as well in translateMath()
-         // In principle, they cannot be used by translators at the moment
-         // because they are blocked by linter. But we will permit them here
-         // in case the linter limitation is lifted in the future.
-         // https://katex.org/?data=%7B%22displayMode%22%3Atrue%2C%22leqno%22%3Afalse%2C%22fleqn%22%3Afalse%2C%22throwOnError%22%3Atrue%2C%22errorColor%22%3A%22%23cc0000%22%2C%22strict%22%3A%22warn%22%2C%22trust%22%3Afalse%2C%22macros%22%3A%7B%22%5C%5Cf%22%3A%22f(%231)%22%7D%2C%22code%22%3A%22%25%20%5C%5Cf%20is%20defined%20as%20f(%231)%20using%20the%20macro%5Cn%5C%5Csin%20%5C%5Carcsin%20%5C%5Ccos%20%5C%5Carccos%20%5C%5C%5C%5C%20%5C%5Ctan%20%5C%5Carctan%20%5C%5Ctg%20%5C%5Carctg%20%5C%5C%5C%5C%5Cn%5C%5Ccot%20%5C%5Ccotg%20%5C%5Cctg%20%5C%5Coperatorname%7Barccot%7D%20%5C%5C%5C%5C%5Cn%5C%5Ccsc%20%5C%5Ccosec%20%5C%5Coperatorname%7Barccsc%7D%20%5C%5C%5C%5C%5Cn%5C%5Coperatorname%7Bsen%7D%7Bx%7D%20%5C%5Csin%7Bx%7D%20%5C%5Csin%20x%22%7D
-         {langs: Array.from(new Set([].concat(
-                 MATH_RULES_LOCALES.TAN_AS_TG,
-                 MATH_RULES_LOCALES.COT_AS_COTG,
-                 MATH_RULES_LOCALES.COT_AS_CTG,
-                 MATH_RULES_LOCALES.CSC_AS_COSEC))),
-            regex: /\\(tg|arctg|cotg|ctg|cosec)/g,
-            replace: '\\operatorname{$1}'},
+        // KaTeX supports more trig functions then default LaTeX
+        // (\tg, \arctg, \cotg \ctg, \cosec)
+        // but we're using \operatorname for them as well in translateMath()
+        // In principle, they cannot be used by translators at the moment
+        // because they are blocked by linter. But we will permit them here
+        // in case the linter limitation is lifted in the future.
+        // https://katex.org/?data=%7B%22displayMode%22%3Atrue%2C%22leqno%22%3Afalse%2C%22fleqn%22%3Afalse%2C%22throwOnError%22%3Atrue%2C%22errorColor%22%3A%22%23cc0000%22%2C%22strict%22%3A%22warn%22%2C%22trust%22%3Afalse%2C%22macros%22%3A%7B%22%5C%5Cf%22%3A%22f(%231)%22%7D%2C%22code%22%3A%22%25%20%5C%5Cf%20is%20defined%20as%20f(%231)%20using%20the%20macro%5Cn%5C%5Csin%20%5C%5Carcsin%20%5C%5Ccos%20%5C%5Carccos%20%5C%5C%5C%5C%20%5C%5Ctan%20%5C%5Carctan%20%5C%5Ctg%20%5C%5Carctg%20%5C%5C%5C%5C%5Cn%5C%5Ccot%20%5C%5Ccotg%20%5C%5Cctg%20%5C%5Coperatorname%7Barccot%7D%20%5C%5C%5C%5C%5Cn%5C%5Ccsc%20%5C%5Ccosec%20%5C%5Coperatorname%7Barccsc%7D%20%5C%5C%5C%5C%5Cn%5C%5Coperatorname%7Bsen%7D%7Bx%7D%20%5C%5Csin%7Bx%7D%20%5C%5Csin%20x%22%7D
+        {langs: Array.from(new Set([].concat(
+            MATH_RULES_LOCALES.TAN_AS_TG,
+            MATH_RULES_LOCALES.COT_AS_COTG,
+            MATH_RULES_LOCALES.COT_AS_CTG,
+            MATH_RULES_LOCALES.CSC_AS_COSEC))),
+        regex: /\\(tg|arctg|cotg|ctg|cosec)/g,
+        replace: '\\operatorname{$1}'},
     ];
 
     mathNormalizations.forEach(function(element) {
@@ -384,10 +384,10 @@ function maybeTranslateMath(math, template, lang) {
         // multiplication sign as a centered dot
         {langs: MATH_RULES_LOCALES.MAYBE_TIMES_AS_CDOT,
             regex: /\\times/g, replace: '\\cdot'},
-         // multiplication sign as x
+        // multiplication sign as x
         {langs: MATH_RULES_LOCALES.MAYBE_CDOT_AS_TIMES,
             regex: /\\cdot/g, replace: '\\times'},
-         // division sign as a colon
+        // division sign as a colon
         {langs: MATH_RULES_LOCALES.MAYBE_DIV_AS_COLON,
             regex: /\\div/g, replace: '\\mathbin{:}'},
     ];
@@ -413,7 +413,7 @@ function maybeTranslateMath(math, template, lang) {
  * but that's handled elsewhere.
  */
 const KATEX_BASE_COLORS = ['blue', 'gold', 'gray', 'mint', 'green', 'red',
-         'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen'];
+    'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen'];
 
 /**
  * Construct regular expression to match decimal numbers for a given lang,
@@ -505,7 +505,7 @@ function getOrderedPairRegexString(lang) {
       `-?[0-9]+|-?${katexColorMacros}\\{-?[0-9]+\\}|-?${katexColorMacros}[0-9]`;
     const variable = `[a-z]|${katexColorMacros}\\{[a-z]\\}`;
     const decimal = getDecNumberRegexString(lang,
-                /* don't include capture groups */ false);
+        /* don't include capture groups */ false);
     const numberOrLetter = `${variable}|${decimal}|${integer}`;
     // NOTE(danielhollas): We allow comma and semicolon for all langs
     // as separators, even though maybe some langs use only comma.
@@ -518,7 +518,7 @@ function getOrderedPairRegexString(lang) {
         separators += '|'; // For German coordinates
     }
     // Support LaTeX spaces, e.g. '4~; 3' (used in e.g. French notation)
-    const space = `(?:\\\\,|~|\\s)*`;
+    const space = '(?:\\\\,|~|\\s)*';
     const sep = `${space}[${separators}]${space}`;
     return `\\s*(${numberOrLetter})(${sep})(${numberOrLetter})\\s*`;
 }
@@ -771,7 +771,7 @@ function translateCoordinatesOrOpenIntervals(math, template, lang) {
 
     // Verify that left and right parentheses|brackets make sense
     // for a given language
-    switch(left) {
+    switch (left) {
     case '[':
         if (right !== ']' ||
             !MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang))

--- a/src/translation-assistant.js
+++ b/src/translation-assistant.js
@@ -10,16 +10,16 @@ const {
 // Matches math delimited by $, e.g.
 // $x^2 + 2x + 1 = 0$
 // $\text{cost} = \$4$
-const MATH_REGEX = /\$(\\\$|[^\$])+\$/g;
+const MATH_REGEX = /\$(\\\$|[^$])+\$/g;
 
 // Matches graphie strings,
 // e.g. ![](web+graphie://ka-perseus-graphie.s3.amazonaws.com/542f2b4e297910eed545a5c29c3866918655bab4)
-const GRAPHIE_REGEX = /\!\[\]\([^)]+\)/g;
+const GRAPHIE_REGEX = /!\[\]\([^)]+\)/g;
 
 // Matches pure image and graphie link strings,
 // e.g. https://ka-perseus-graphie.s3.amazonaws.com/e75c49cb5753492629016169933ab63af3b9f122.png
 // or web+graphie://ka-perseus-graphie.s3.amazonaws.com/542f2b4e297910eed545a5c29c3866918655bab4
-const IMAGE_REGEX = /https:[^\s]+\.png|web\+graphie:[a-z0-9\.\-/]+(?=[\s,]|$)/g;
+const IMAGE_REGEX = /https:[^\s]+\.png|web\+graphie:[a-z0-9.\-/]+(?=[\s,]|$)/g;
 
 // Matches widget strings, e.g. [[☃ Expression 1]]
 const WIDGET_REGEX = /\[\[[\u2603][^\]]+\]\]/g;
@@ -282,7 +282,7 @@ function getMathDictionary(englishStr, translatedStr, lang) {
             if (match.test(key)) {
                 const input = inputMap[key];
 
-                if (!outputMap.hasOwnProperty(key)) {
+                if (!Object.prototype.hasOwnProperty.call(outputMap, key)) {
                     // If outputMap is missing a key that exists in inputMap it
                     // means that the math differs between the input and output
                     // and getMapping will throw and error in that case.
@@ -370,7 +370,7 @@ function createTemplate(englishStr, translatedStr, lang) {
                 getMapping(englishStr, translatedStr, lang, WIDGET_REGEX),
             mathDictionary: translatedDictionary,
         };
-    } catch(e) {
+    } catch (e) {
         return e;
     }
 }
@@ -394,7 +394,7 @@ function rtrim(str) {
  * @returns {String} The string with escaped characters
  */
 function escapeForRegex(str) {
-    return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    return str.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
 /**
@@ -419,7 +419,7 @@ function replaceTextInMath(englishMath, dict) {
         textCommands.forEach((cmd) => {
             const escapedEnglishText = escapeForRegex(englishText);
             const regex = new RegExp(`\\\\${cmd}(\\s*){${escapedEnglishText}}`,
-                  'g');
+                'g');
             // make sure the spacing matches in the replacement
             const replacement = `\\${cmd}$1{${translatedText}}`;
             translatedMath = translatedMath.replace(regex, replacement);
@@ -464,14 +464,15 @@ function populateTemplate(template, englishStr, lang) {
             englishMapping = getMapping(
                 englishStr, englishStr, 'en', MATH_REGEX, englishDictionary);
         } catch (error) {
-            console.error(  // eslint-disable-line no-console
+            // eslint-disable-next-line no-console
+            console.error(
                 'Unexpected error in TranslationAssistant.populateTemplate');
             return undefined;
         }
         // And verify that the math mapping is identical to the one in the
         // template.
         if (JSON.stringify(englishMapping) !== JSON.stringify(
-                template.mathMapping.englishToEnglish)) {
+            template.mathMapping.englishToEnglish)) {
             // Inappropriate mapping can result in math being altered between
             // the English string and the suggested translation string.
             // For example a template created from string '$4$ x $4$ y $5$'
@@ -498,8 +499,8 @@ function populateTemplate(template, englishStr, lang) {
     let widgetIndex = 0;
 
     maths = maths
-      .map((math) => translateMath(math, allTranslatedMaths, lang))
-      .map((math) => replaceTextInMath(math, template.mathDictionary));
+        .map((math) => translateMath(math, allTranslatedMaths, lang))
+        .map((math) => replaceTextInMath(math, template.mathDictionary));
 
     return englishLines.map((englishLine, index) => {
         const templateLine = template.lines[index];
@@ -590,11 +591,12 @@ class TranslationAssistant {
             // Widgets should never be changed.
             // TODO(kevinb) handle multiple non-nl_text items
             if (/^(__GRAPHIE__|__IMAGE__|__WIDGET__)$/
-                    .test(normalObj.str)) {
+                .test(normalObj.str)) {
                 return [item, englishStr];
             }
 
-            if (suggestionGroups.hasOwnProperty(normalStr)) {
+            if (Object.prototype.hasOwnProperty.
+                call(suggestionGroups, normalStr)) {
                 const {template} = suggestionGroups[normalStr];
 
                 // This error is probably due to math being different between

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -78,7 +78,7 @@ const getTranslation = (item) => item.translatedStr;
  * @returns {void}
  */
 function assertSuggestions(allItems, itemsToTranslate, translatedStrs,
-        lang = 'cs') {
+    lang = 'cs') {
     const assistant =
         new TranslationAssistant(allItems, getEnglishStr, getTranslation, lang);
 
@@ -192,28 +192,28 @@ describe('TranslationAssistant', function() {
         });
 
         it('should return null when there\'s nl text inside \\text{}',
-        function() {
-            const allItems = [];
-            const itemsToTranslate = [{
-                englishStr: '$\\text {simplify } 3x = 9$',
-                translatedStr: '',
-            }];
-            const translatedStrs = [null];
+            function() {
+                const allItems = [];
+                const itemsToTranslate = [{
+                    englishStr: '$\\text {simplify } 3x = 9$',
+                    translatedStr: '',
+                }];
+                const translatedStrs = [null];
 
-            assertSuggestions(allItems, itemsToTranslate, translatedStrs);
-        });
+                assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+            });
 
         it('should return null when there\'s nl text inside \\textbf{}',
-        function() {
-            const allItems = [];
-            const itemsToTranslate = [{
-                englishStr: '$\\textbf {simplify } 3x = 9$',
-                translatedStr: '',
-            }];
-            const translatedStrs = [null];
+            function() {
+                const allItems = [];
+                const itemsToTranslate = [{
+                    englishStr: '$\\textbf {simplify } 3x = 9$',
+                    translatedStr: '',
+                }];
+                const translatedStrs = [null];
 
-            assertSuggestions(allItems, itemsToTranslate, translatedStrs);
-        });
+                assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+            });
 
         it('should return the same math', function() {
             const allItems = [];
@@ -256,22 +256,22 @@ describe('TranslationAssistant', function() {
         });
 
         it('should return the same graphie even if translator changed one',
-        function() {
-            const allItems = [{
-                englishStr: graphie1,
-                translatedStr: graphie2,
-            }];
-            const itemsToTranslate = [{
-                englishStr: graphie3,
-                translatedStr: '',
-            }, {
-                englishStr: 'hello',
-                translatedStr: '',
-            }];
-            const translatedStr = [graphie3, null];
+            function() {
+                const allItems = [{
+                    englishStr: graphie1,
+                    translatedStr: graphie2,
+                }];
+                const itemsToTranslate = [{
+                    englishStr: graphie3,
+                    translatedStr: '',
+                }, {
+                    englishStr: 'hello',
+                    translatedStr: '',
+                }];
+                const translatedStr = [graphie3, null];
 
-            assertSuggestions(allItems, itemsToTranslate, translatedStr);
-        });
+                assertSuggestions(allItems, itemsToTranslate, translatedStr);
+            });
 
         it('should return the same image link', function() {
             const imageLink = makeImageLink();
@@ -289,22 +289,22 @@ describe('TranslationAssistant', function() {
         });
 
         it('should return the same imageLink even if translator changed one',
-        function() {
-            const allItems = [{
-                englishStr: image1,
-                translatedStr: image2,
-            }];
-            const itemsToTranslate = [{
-                englishStr: image3,
-                translatedStr: '',
-            }, {
-                englishStr: 'hello',
-                translatedStr: '',
-            }];
-            const translatedStr = [image3, null];
+            function() {
+                const allItems = [{
+                    englishStr: image1,
+                    translatedStr: image2,
+                }];
+                const itemsToTranslate = [{
+                    englishStr: image3,
+                    translatedStr: '',
+                }, {
+                    englishStr: 'hello',
+                    translatedStr: '',
+                }];
+                const translatedStr = [image3, null];
 
-            assertSuggestions(allItems, itemsToTranslate, translatedStr);
-        });
+                assertSuggestions(allItems, itemsToTranslate, translatedStr);
+            });
     });
 });
 
@@ -616,7 +616,7 @@ describe('TranslationAssistant (math-translate)', function() {
         const allItems = [];
         const itemsToTranslate = [
             {englishStr: '$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000 $',
-             translatedStr: ''},
+                translatedStr: ''},
         ];
         const translatedStrs =
            ['$3\\,000{,}5 \\cdot x = 9{,}9 \\mathbin{:} 3\\,300\\,000 $'];
@@ -625,23 +625,24 @@ describe('TranslationAssistant (math-translate)', function() {
     });
 
     it('should handle both thousand sep. AND decimal comma for cs locale',
-    function() {
-        const allItems = [];
-        const itemsToTranslate = [
-            {englishStr: '$3{,}000.500 \\times x = 9.900 \\div 3{,}300{,}000 $',
-             translatedStr: ''},
-        ];
-        const translatedStrs =
+        function() {
+            const allItems = [];
+            const itemsToTranslate = [
+                {englishStr:
+                    '$3{,}000.500 \\times x = 9.900 \\div 3{,}300{,}000 $',
+                translatedStr: ''},
+            ];
+            const translatedStrs =
            ['$3\\,000{,}500 \\cdot x = 9{,}900 \\mathbin{:} 3\\,300\\,000 $'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
-    });
+            assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+        });
 
     it('should not translate thousand separator for ja locale', function() {
         const allItems = [];
         const itemsToTranslate = [
             {englishStr: '$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000$',
-             translatedStr: ''},
+                translatedStr: ''},
         ];
         const translatedStrs =
            ['$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000$'];
@@ -650,19 +651,19 @@ describe('TranslationAssistant (math-translate)', function() {
     });
 
     it('should handle extra braces around thousand separator as thin space',
-    function() {
-        const allItems = [{
-            englishStr: 'simplify $2{,}300 20{,}000{,}090$',
-            translatedStr: 'simplifyz $2{\\,}300 20{\\,}000{\\,}090$',
-        }];
-        const itemsToTranslate = [{
-            englishStr: 'simplify $2{,}000{,}000$',
-            translatedStr: '',
-        }];
-        const translatedStrs = ['simplifyz $2\\,000\\,000$'];
+        function() {
+            const allItems = [{
+                englishStr: 'simplify $2{,}300 20{,}000{,}090$',
+                translatedStr: 'simplifyz $2{\\,}300 20{\\,}000{\\,}090$',
+            }];
+            const itemsToTranslate = [{
+                englishStr: 'simplify $2{,}000{,}000$',
+                translatedStr: '',
+            }];
+            const translatedStrs = ['simplifyz $2\\,000\\,000$'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs);
-    });
+            assertSuggestions(allItems, itemsToTranslate, translatedStrs);
+        });
 
     it('should allow ~ as a thousand separator', function() {
         const allItems = [{
@@ -710,7 +711,7 @@ describe('TranslationAssistant (math-translate)', function() {
         const allItems = [];
         const itemsToTranslate = [
             {englishStr: '$3{,}000.500 \\times x = 9.900 \\div 3{,}300{,}000$',
-             translatedStr: ''},
+                translatedStr: ''},
         ];
         const translatedStrs =
            ['$3000.500 \\times x = 9.900 \\div 3300000$'];
@@ -722,7 +723,7 @@ describe('TranslationAssistant (math-translate)', function() {
         const allItems = [];
         const itemsToTranslate = [
             {englishStr: '$3{,}000.5 \\times x = 9.9 \\div 3{,}300{,}000 $',
-             translatedStr: ''},
+                translatedStr: ''},
         ];
         const translatedStrs =
            ['$3.000{,}5 \\times x = 9{,}9 \\div 3.300.000 $'];
@@ -731,17 +732,18 @@ describe('TranslationAssistant (math-translate)', function() {
     });
 
     it('should handle thousand separator AND decimal comma for pt locale',
-    function() {
-        const allItems = [];
-        const itemsToTranslate = [
-            {englishStr: '$3{,}000.540 \\times x = 9.900 \\div 3{,}300{,}000 $',
-             translatedStr: ''},
-        ];
-        const translatedStrs =
+        function() {
+            const allItems = [];
+            const itemsToTranslate = [
+                {englishStr:
+                    '$3{,}000.540 \\times x = 9.900 \\div 3{,}300{,}000 $',
+                translatedStr: ''},
+            ];
+            const translatedStrs =
            ['$3.000{,}540 \\times x = 9{,}900 \\div 3.300.000 $'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'pt');
-    });
+            assertSuggestions(allItems, itemsToTranslate, translatedStrs, 'pt');
+        });
 
     it('should translate math with \\text', function() {
         const allItems = [{
@@ -932,19 +934,19 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
     });
 
     it('should NOT translate if template contains conflicting notation',
-    function() {
-        const lang = MATH_RULES_LOCALES.MAYBE_TIMES_AS_CDOT[0];
-        const allItems = [
-            {englishStr: 'Simplify $3 \\times x \\times y$',
-            translatedStr: 'Simplifyz $3 \\cdot x \\times y$'},
-        ];
-        const itemsToTranslate = [
-            {englishStr: 'Simplify $6 \\times y$', translatedStr: ''},
-        ];
-        const translatedStrs = [null];
+        function() {
+            const lang = MATH_RULES_LOCALES.MAYBE_TIMES_AS_CDOT[0];
+            const allItems = [
+                {englishStr: 'Simplify $3 \\times x \\times y$',
+                    translatedStr: 'Simplifyz $3 \\cdot x \\times y$'},
+            ];
+            const itemsToTranslate = [
+                {englishStr: 'Simplify $6 \\times y$', translatedStr: ''},
+            ];
+            const translatedStrs = [null];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
-    });
+            assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+        });
 
     it('should translate only math present in the template', function() {
         const lang = 'id';
@@ -953,7 +955,7 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
 
         const allItems = [
             {englishStr: '$6 \\div 3$',
-             translatedStr: '$6 \\mathbin{:} 3$',
+                translatedStr: '$6 \\mathbin{:} 3$',
             },
         ];
         const itemsToTranslate = [
@@ -977,7 +979,7 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
         const lang = 'id';
         const allItems = [
             {englishStr: '$6 \\div 3 \\times y$',
-             translatedStr: '$6 \\mathbin{:} 3 \\cdot y$',
+                translatedStr: '$6 \\mathbin{:} 3 \\cdot y$',
             },
         ];
         const itemsToTranslate = [
@@ -1036,19 +1038,19 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
     });
 
     it('should detect and translate coordinates in math-only strings',
-    function() {
-        const lang = 'cs';
-        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
-        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
+        function() {
+            const lang = 'cs';
+            assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
+            assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
 
-        const allItems = [];
-        const itemsToTranslate = [
-            {englishStr: '$(2,1) (x,y) (\\green4,1.5)$', translatedStr: ''},
-        ];
-        const translatedStrs = ['$[2;1] [x;y] [\\green4;1{,}5]$'];
+            const allItems = [];
+            const itemsToTranslate = [
+                {englishStr: '$(2,1) (x,y) (\\green4,1.5)$', translatedStr: ''},
+            ];
+            const translatedStrs = ['$[2;1] [x;y] [\\green4;1{,}5]$'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
-    });
+            assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+        });
 
     it('should handle superflous spaces in English coordinates', function() {
         const lang = 'cs';
@@ -1057,7 +1059,7 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
 
         const allItems = [
             {englishStr: 'coordinates $( 0,1)$',
-             translatedStr: 'souradnice $[0;1]$'},
+                translatedStr: 'souradnice $[0;1]$'},
         ];
         const itemsToTranslate = [
             {englishStr: 'coordinates $( 2, 1)$', translatedStr: ''},
@@ -1074,7 +1076,7 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
 
         const allItems = [
             {englishStr: 'coordinates $(0,1 )$',
-             translatedStr: 'souradnice $[0; 1 ]$'},
+                translatedStr: 'souradnice $[0; 1 ]$'},
         ];
         const itemsToTranslate = [
             {englishStr: 'coordinates $(2,1)$', translatedStr: ''},
@@ -1085,24 +1087,26 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
     });
 
     it('should translate both coordinates and intervals in separate math bits',
-    function() {
-        const lang = 'cs';
-        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
-        assert(MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS.includes(lang));
-        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
+        function() {
+            const lang = 'cs';
+            assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
+            assert(MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS
+                .includes(lang));
+            assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
 
-        const allItems = [
-            {englishStr: 'Intervals $[0,3] (-1,3)$ coordinates $(0,0)$',
-            translatedStr: 'Ints $⟨0;3⟩ (-1;3)$ coords $[0;0]$'},
-        ];
-        const itemsToTranslate = [
-            {englishStr: 'Intervals $[0,3) (-5,\\red3]$ coordinates $(-1,-1)$',
-            translatedStr: ''},
-        ];
-        const translatedStrs = ['Ints $⟨0;3) (-5;\\red3⟩$ coords $[-1;-1]$'];
+            const allItems = [
+                {englishStr: 'Intervals $[0,3] (-1,3)$ coordinates $(0,0)$',
+                    translatedStr: 'Int $⟨0;3⟩ (-1;3)$ coords $[0;0]$'},
+            ];
+            const itemsToTranslate = [
+                {englishStr:
+                    'Intervals $[0,3) (-5,\\red3]$ coordinates $(-1,-1)$',
+                translatedStr: ''},
+            ];
+            const translatedStrs = ['Int $⟨0;3) (-5;\\red3⟩$ coords $[-1;-1]$'];
 
-        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
-    });
+            assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+        });
 
     it('should translate open intervals according to a template', function() {
         const lang = 'fr';
@@ -1110,11 +1114,11 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
 
         const allItems = [
             {englishStr: 'Open intervals $(0,3) (\\blueD{-1},0)$',
-            translatedStr: 'Ints $]0~;3[ ]\\blueD{-1}~;0[$'},
+                translatedStr: 'Ints $]0~;3[ ]\\blueD{-1}~;0[$'},
         ];
         const itemsToTranslate = [
             {englishStr: 'Open intervals $(0,3)$',
-            translatedStr: ''},
+                translatedStr: ''},
         ];
         const translatedStrs = ['Ints $]0~;3[$'];
 
@@ -1128,13 +1132,13 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
 
         const allItems = [
             {englishStr: 'Coordinates $(0,3.\\overline{3}) (\\blueD{-1},0)$',
-            translatedStr: 'Coords $[0;3{,}\\overline{3}] [\\blueD{-1};0]$'},
+                translatedStr: 'Cords $[0;3{,}\\overline{3}] [\\blueD{-1};0]$'},
         ];
         const itemsToTranslate = [
             {englishStr: 'Coordinates $(0,3)$',
-            translatedStr: ''},
+                translatedStr: ''},
         ];
-        const translatedStrs = ['Coords $[0;3]$'];
+        const translatedStrs = ['Cords $[0;3]$'];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });

--- a/tests/math_translator_spec.js
+++ b/tests/math_translator_spec.js
@@ -62,12 +62,12 @@ describe('MathTranslator (translateMath)', function() {
     });
 
     it('should translate both thousand sep. and decimal point for cs locale',
-    function() {
-        const englishStr = '1{,}000{,}000.700 + 9{,}000.000';
-        const translatedStr = '1\\,000\\,000{,}700 + 9\\,000{,}000';
-        const outputStr = translateMath(englishStr, '', 'cs');
-        assert.equal(outputStr, translatedStr);
-    });
+        function() {
+            const englishStr = '1{,}000{,}000.700 + 9{,}000.000';
+            const translatedStr = '1\\,000\\,000{,}700 + 9\\,000{,}000';
+            const outputStr = translateMath(englishStr, '', 'cs');
+            assert.equal(outputStr, translatedStr);
+        });
 
     it('should translate notation for multiplication', function() {
         MATH_RULES_LOCALES.TIMES_AS_CDOT.forEach(function(locale) {
@@ -164,12 +164,12 @@ describe('MathTranslator (translateMath)', function() {
     });
 
     it('should use arabic decimal comma and no thousand separator for pashto',
-    function() {
-        const englishStr = '1{,}234{,}567.890';
-        const translatedStr = '۱۲۳۴۵۶۷{،}۸۹۰';
-        const outputStr = translateMath(englishStr, '', 'ps');
-        assert.equal(outputStr, translatedStr);
-    });
+        function() {
+            const englishStr = '1{,}234{,}567.890';
+            const translatedStr = '۱۲۳۴۵۶۷{،}۸۹۰';
+            const outputStr = translateMath(englishStr, '', 'ps');
+            assert.equal(outputStr, translatedStr);
+        });
 
     it('should translate repeating decimal numbers', function() {
         // We cannot iterate over all locales from DECIMAL_COMMA
@@ -191,26 +191,26 @@ describe('MathTranslator (translateMath)', function() {
     });
 
     it('should translate \\overline in repeating decimals as \\dot',
-    function() {
-        const locale = 'bn';
-        assert(MATH_RULES_LOCALES.OVERLINE_AS_DOT.includes(locale));
+        function() {
+            const locale = 'bn';
+            assert(MATH_RULES_LOCALES.OVERLINE_AS_DOT.includes(locale));
 
-        const englishStr = '1.\\overline{3} + 9.\\overline{44}';
-        const translatedStr = '1.\\dot{3} + 9.\\dot{4}\\dot{4}';
-        const outputStr = translateMath(englishStr, '', locale);
-        assert.equal(outputStr, translatedStr);
-    });
+            const englishStr = '1.\\overline{3} + 9.\\overline{44}';
+            const translatedStr = '1.\\dot{3} + 9.\\dot{4}\\dot{4}';
+            const outputStr = translateMath(englishStr, '', locale);
+            assert.equal(outputStr, translatedStr);
+        });
 
     it('should translate \\overline in repeating decimals as parentheses',
-    function() {
-        const locale = 'pt-pt';
-        assert(MATH_RULES_LOCALES.OVERLINE_AS_PARENS.includes(locale));
+        function() {
+            const locale = 'pt-pt';
+            assert(MATH_RULES_LOCALES.OVERLINE_AS_PARENS.includes(locale));
 
-        const englishStr = '1.\\overline{3} + 9.\\overline{44}';
-        const translatedStr = '1{,}(3) + 9{,}(44)';
-        const outputStr = translateMath(englishStr, '', locale);
-        assert.equal(outputStr, translatedStr);
-    });
+            const englishStr = '1.\\overline{3} + 9.\\overline{44}';
+            const translatedStr = '1{,}(3) + 9{,}(44)';
+            const outputStr = translateMath(englishStr, '', locale);
+            assert.equal(outputStr, translatedStr);
+        });
 
     it('should translate decimals wrapped in color commands', function() {
         const englishStr =
@@ -251,44 +251,49 @@ describe('MathTranslator (translateMath)', function() {
 
 describe('MathTranslator (normalizeTranslatedMath)', function() {
     it('should strip extra braces around thousand separator as thin space',
-    function() {
-        const translatedStr = '1{\\,}000{\\,}000 + 9\\,000';
-        const normalizedStr = '1\\,000\\,000 + 9\\,000';
+        function() {
+            const translatedStr = '1{\\,}000{\\,}000 + 9\\,000';
+            const normalizedStr = '1\\,000\\,000 + 9\\,000';
 
-        MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.forEach(function(locale) {
-            const outputStr = normalizeTranslatedMath(translatedStr, locale);
-            assert.equal(outputStr, normalizedStr);
+            MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.forEach(
+                function(locale) {
+                    const outputStr =
+                        normalizeTranslatedMath(translatedStr, locale);
+                    assert.equal(outputStr, normalizedStr);
+                });
         });
-    });
 
     it('should strip extra braces around thousand separator as a dot',
-    function() {
-        const translatedStr = '1{.}000{.}000 + 9.000 + 1{,}2';
-        const normalizedStr = '1.000.000 + 9.000 + 1{,}2';
+        function() {
+            const translatedStr = '1{.}000{.}000 + 9.000 + 1{,}2';
+            const normalizedStr = '1.000.000 + 9.000 + 1{,}2';
 
-        MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT.forEach(function(locale) {
-            const outputStr = normalizeTranslatedMath(translatedStr, locale);
-            assert.equal(outputStr, normalizedStr);
+            MATH_RULES_LOCALES.THOUSAND_SEP_AS_DOT
+                .forEach(function(locale) {
+                    const outputStr =
+                        normalizeTranslatedMath(translatedStr, locale);
+                    assert.equal(outputStr, normalizedStr);
+                });
         });
-    });
 
     it('should not strip extra braces around thousand separator for en locale',
-    function() {
-        const translatedStr = '1{\\,}000{\\,}000 + 9\\,000';
-        const normalizedStr = '1{\\,}000{\\,}000 + 9\\,000';
-        const outputStr = normalizeTranslatedMath(translatedStr, 'en');
-        assert.equal(outputStr, normalizedStr);
-    });
+        function() {
+            const translatedStr = '1{\\,}000{\\,}000 + 9\\,000';
+            const normalizedStr = '1{\\,}000{\\,}000 + 9\\,000';
+            const outputStr = normalizeTranslatedMath(translatedStr, 'en');
+            assert.equal(outputStr, normalizedStr);
+        });
 
     it('should convert ~ to thin space as thousand separator', function() {
         const translatedStr = '1~000~000 + 9~000';
         const normalizedStr = '1\\,000\\,000 + 9\\,000';
 
         MATH_RULES_LOCALES.THOUSAND_SEP_AS_THIN_SPACE.forEach(
-        function(locale) {
-            const outputStr = normalizeTranslatedMath(translatedStr, locale);
-            assert.equal(outputStr, normalizedStr);
-        });
+            function(locale) {
+                const outputStr =
+                    normalizeTranslatedMath(translatedStr, locale);
+                assert.equal(outputStr, normalizedStr);
+            });
     });
 
     it('should convert {~} to thin space as thousand separator', function() {
@@ -322,13 +327,13 @@ describe('MathTranslator (normalizeTranslatedMath)', function() {
     });
 
     it('should strip extra space in coordinates/intervals',
-    function() {
+        function() {
         // Striping space after opening brackets and before closing brackets
-        const translatedStr = '( 1,2 ) [ 3; 4] ] 1~,2[ ⟨ a;\\red5 ⟩';
-        const normalizedStr = '(1,2) [3; 4] ]1~,2[ ⟨a;\\red5⟩';
-        const outputStr = normalizeTranslatedMath(translatedStr, 'cs');
-        assert.equal(outputStr, normalizedStr);
-    });
+            const translatedStr = '( 1,2 ) [ 3; 4] ] 1~,2[ ⟨ a;\\red5 ⟩';
+            const normalizedStr = '(1,2) [3; 4] ]1~,2[ ⟨a;\\red5⟩';
+            const outputStr = normalizeTranslatedMath(translatedStr, 'cs');
+            assert.equal(outputStr, normalizedStr);
+        });
 });
 
 describe('MathTranslator (maybeTranslateMath)', function() {
@@ -532,28 +537,28 @@ describe('MathTranslator (maybeTranslateMath)', function() {
     });
 
     it('should only support coord/interval notation specific for given lang',
-    function() {
-        let locale = 'fr';
-        assert(!MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(locale));
+        function() {
+            let locale = 'fr';
+            assert(!MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(locale));
 
-        const englishStr = '(a, b) (1,2)';
-        const translatedStr = englishStr;
-        let template = '[1,2]';
-        let output = maybeTranslateMath(englishStr, template, locale);
-        assert.equal(output, translatedStr);
+            const englishStr = '(a, b) (1,2)';
+            const translatedStr = englishStr;
+            let template = '[1,2]';
+            let output = maybeTranslateMath(englishStr, template, locale);
+            assert.equal(output, translatedStr);
 
-        locale = 'cs';
-        assert(!MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(locale));
-        template = ']1,2[';
-        output = maybeTranslateMath(englishStr, template, locale);
-        assert.equal(output, translatedStr);
+            locale = 'cs';
+            assert(!MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(locale));
+            template = ']1,2[';
+            output = maybeTranslateMath(englishStr, template, locale);
+            assert.equal(output, translatedStr);
 
-        locale = 'bg';
-        assert(!MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(locale));
-        template = '[1,2]';
-        output = maybeTranslateMath(englishStr, template, locale);
-        assert.equal(output, translatedStr);
-    });
+            locale = 'bg';
+            assert(!MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(locale));
+            template = '[1,2]';
+            output = maybeTranslateMath(englishStr, template, locale);
+            assert.equal(output, translatedStr);
+        });
 
     it('should translate closed intervals without template', function() {
         const locale = 'fr';
@@ -696,16 +701,16 @@ describe('detectCoordinates', function() {
     });
 
     it('should NOT detect coordinates that could also be open intervals',
-    function() {
-        let englishMath = '(2.1,4)';
-        assert(!detectCoordinates(englishMath));
+        function() {
+            let englishMath = '(2.1,4)';
+            assert(!detectCoordinates(englishMath));
 
-        englishMath = '(2,b)';
-        assert(!detectCoordinates(englishMath));
+            englishMath = '(2,b)';
+            assert(!detectCoordinates(englishMath));
 
-        englishMath = '(a,b)';
-        assert(!detectCoordinates(englishMath));
-    });
+            englishMath = '(a,b)';
+            assert(!detectCoordinates(englishMath));
+        });
 });
 
 describe('MATH_RULES_LOCALES', function() {
@@ -768,7 +773,8 @@ describe('MATH_RULES_LOCALES', function() {
     it('should not have conflicting rules for intervals', function() {
         MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.forEach(function(locale) {
             assert(
-            ! MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS.includes(locale)
+                ! MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS
+                    .includes(locale)
             );
         });
     });


### PR DESCRIPTION
I tried out Dependabot suggestion and bumped the Eslint version.

The new version is much stricter for indentation and max-len-per-line rules, but fortunately most of these could be autofixed
and the remaining issues were not too difficult to fix by hand. There was one rule which was deprecated / renamed.

If we decided to merge this, we should then add that commit hash to a file `.git-blame-ignore-revs` so that git blame can ignore it.
https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame
Unfortunately it seems that GitHub does not support this natively yet.
https://github.community/t/support-ignore-revs-file-in-githubs-blame-view/3256