### PR TITLE
Add ESlint bump commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# ESLint version bump
+8f7a2bd2ceb467fd3cabfc9442dc6c793a801852


### PR DESCRIPTION
Closes #37
To ignore this commit in blame history, use:
git blame --ignore-revs-file .git-blame-ignore-revs

or to do it automatically:
git config blame.ignoreRevsFile .git-blame-ignore-revs

FYI @mpolyak 