### PR TITLE
Handle more complicated expressions in coordinates/intervals

### DIFF
--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -402,7 +402,7 @@ function getDecNumberRegexString(lang) {
     // were defined at some point
     var katexColorMacros = KATEX_BASE_COLORS.join('|');
 
-    var integerPart = '[0-9]+|\\\\(?:' + katexColorMacros + ')[A-Z]?\\{[0-9]+\\}';
+    var integerPart = '-?[0-9]+|-?\\\\(?:' + katexColorMacros + ')[A-Z]?\\{-?[0-9]+\\}';
     // Decimal part is different from integer part
     // because it can contain \\overline
     // TODO: Some langs do not use \\overline, but \\dot
@@ -454,13 +454,21 @@ function getEscapedDecimalSeparator(lang) {
  */
 function getOrderedPairRegexString(lang) {
     var katexColorMacros = '\\\\(?:' + KATEX_BASE_COLORS.join('|') + ')[A-Z]?';
-    // Assuming single-letter variables and numbers below 1000
-    // (without thousand separator)
+    // Assuming single-letter variables (or \pi) and numbers below 1000
+    // (without thousand separator) or combinations, such as '2\\pi' or '2.1b'
     var integer = '-?[0-9]+|-?' + katexColorMacros + '\\{-?[0-9]+\\}|-?' + katexColorMacros + '[0-9]';
-    var variable = '[a-z]|' + katexColorMacros + '\\{[a-z]\\}';
+    var variable = '\\\\pi|[a-z]|' + katexColorMacros + '\\{[a-z]\\}';
     var decimal = getDecNumberRegexString(lang,
     /* don't include capture groups */false);
-    var numberOrLetter = variable + '|' + decimal + '|' + integer;
+
+    var fracArgument = '(?:' + variable + '|' + integer + ')';
+    // Match '\\frac{1}{2}'
+    var frac = '-?\\\\d?frac\\{' + fracArgument + '\\}\\{' + fracArgument + '\\}';
+    // Match '\frac{3}{4}\\pi'
+    frac = '' + frac + fracArgument + '?';
+
+    var numberAndOrLetter = frac + '|' + variable + '|(?:' + decimal + '|' + integer + ')(?:' + variable + ')?';
+
     // NOTE(danielhollas): We allow comma and semicolon for all langs
     // as separators, even though maybe some langs use only comma.
     // Since the US strings always have commas (I think),
@@ -474,7 +482,7 @@ function getOrderedPairRegexString(lang) {
     // Support LaTeX spaces, e.g. '4~; 3' (used in e.g. French notation)
     var space = '(?:\\\\,|~|\\s)*';
     var sep = space + '[' + separators + ']' + space;
-    return '\\s*(' + numberOrLetter + ')(' + sep + ')(' + numberOrLetter + ')\\s*';
+    return '\\s*(' + numberAndOrLetter + ')(' + sep + ')(' + numberAndOrLetter + ')\\s*';
 }
 
 /**
@@ -493,10 +501,12 @@ function getOrderedPairRegexString(lang) {
 function detectClosedInterval(math) {
     var lang = 'en';
     var interval = getOrderedPairRegexString(lang);
-    var closedInterval = '\\[' + interval + '\\]';
-    var leftClosedInterval = '\\[' + interval + '\\)';
-    var rightClosedInterval = '\\(' + interval + '\\]';
-    return math.match(closedInterval) || math.match(leftClosedInterval) || math.match(rightClosedInterval);
+
+    var closedInterval = new RegExp(wrapParens(interval, '[', ']'), 'g');
+    var leftClosedInterval = new RegExp(wrapParens(interval, '[', ')'), 'g');
+    var rightClosedInterval = new RegExp(wrapParens(interval, '(', ']'), 'g');
+
+    return closedInterval.test(math) || leftClosedInterval.test(math) || rightClosedInterval.test(math);
 }
 
 /**
@@ -513,7 +523,7 @@ function detectClosedInterval(math) {
 function detectCoordinates(math) {
     var lang = 'en';
     var coords = getOrderedPairRegexString(lang);
-    var coordsRegex = new RegExp('\\(' + coords + '\\)', 'g');
+    var coordsRegex = new RegExp(wrapParens(coords, '(', ')'), 'g');
     var match = undefined;
     while ((match = coordsRegex.exec(math)) !== null && match.length === 4) {
         // Remove color commands around numbers
@@ -556,6 +566,26 @@ function getSeparator(template, regex, lang) {
 }
 
 /**
+ * A helper function for building coordinates/intervals regexes.
+ *
+ * The input regex string is wrapped in custom left and right
+ * parentheses and the optional LaTeX \left and \right commands are added
+ * (these are used by content creators so that the sizes of parentheses
+ * respect the size of the expression that is inside them).
+ *
+ * @param {string} regex Regex string to be wrapped in parentheses
+ * @param {string} left left parenthesis character
+ * @param {string} right right parenthesis character
+ * @param {bool} capture capture the \left|\right commands?
+ * @returns {string} Regex string
+ */
+function wrapParens(regex, left, right) {
+    var capture = arguments.length <= 3 || arguments[3] === undefined ? false : arguments[3];
+
+    if (capture) return '(\\\\left)?\\' + left + regex + '(\\\\right)?\\' + right;else return '(?:\\\\left)?\\' + left + regex + '(?:\\\\right)?\\' + right;
+}
+
+/**
  * Translates notation for cartesian coordinates, such as:
  * (3,0) or (x,y)
  *
@@ -569,27 +599,27 @@ function getSeparator(template, regex, lang) {
  */
 function translateCoordinates(math, template, lang) {
     var coordsUS = getOrderedPairRegexString('en');
-    var coordsRegexUS = new RegExp('\\(' + coordsUS + '\\)', 'g');
 
     var coords = getOrderedPairRegexString(lang);
     var coordsRegex = undefined;
     if (MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang)) {
-        coordsRegex = new RegExp('\\[' + coords + '\\]');
+        coordsRegex = new RegExp(wrapParens(coords, '[', ']'));
     } else {
-        coordsRegex = new RegExp('\\(' + coords + '\\)');
+        coordsRegex = new RegExp(wrapParens(coords, '(', ')'));
     }
 
     var sep = getSeparator(template, coordsRegex, lang);
 
+    var coordsRegexUS = new RegExp(wrapParens(coordsUS, '(', ')', true), 'g');
     var coordsTranslations = [{ langs: MATH_RULES_LOCALES.COORDS_AS_BRACKETS,
-        regex: coordsRegexUS, replace: '[$1' + sep + '$3]' }];
+        regex: coordsRegexUS, replace: '$1[$2' + sep + '$4$5]' }];
 
     coordsTranslations.forEach(function (el) {
         if (el.langs.includes(lang)) {
             math = math.replace(el.regex, el.replace);
         } else {
             // For all other langs translate only the separator
-            math = math.replace(el.regex, '($1' + sep + '$3)');
+            math = math.replace(el.regex, '$1($2' + sep + '$4$5)');
         }
     });
 
@@ -607,37 +637,37 @@ function translateCoordinates(math, template, lang) {
  */
 function translateIntervals(math, template, lang) {
     var intervalUS = getOrderedPairRegexString('en');
-    var closedInterval = new RegExp('\\[' + intervalUS + '\\]', 'g');
-    var openInterval = new RegExp('\\(' + intervalUS + '\\)', 'g');
-    var leftClosedInterval = new RegExp('\\[' + intervalUS + '\\)', 'g');
-    var rightClosedInterval = new RegExp('\\(' + intervalUS + '\\]', 'g');
+    var closedInterval = new RegExp(wrapParens(intervalUS, '[', ']', true), 'g');
+    var openInterval = new RegExp(wrapParens(intervalUS, '(', ')', true), 'g');
+    var leftClosedInterval = new RegExp(wrapParens(intervalUS, '[', ')', true), 'g');
+    var rightClosedInterval = new RegExp(wrapParens(intervalUS, '(', ']', true), 'g');
 
     // Detect range separator in the template, can be comma or semicolon
     // We expect that if template contains more intervals, they will have
     // the same separator. The can also include any whitespace chars.
     // Again, these need to be consistent in all intervals!
     var interval = getOrderedPairRegexString(lang);
-    var generalInterval = new RegExp('[[(\\]]' + interval + '[[)\\]]');
+    var generalInterval = new RegExp('(?:\\\\left)?[[(\\]]' + interval + '(?:\\\\right)?[[)\\]]');
 
     var sep = getSeparator(template, generalInterval, lang);
 
     var intervalTranslations = [
     // open intervals with inverted brackets
     { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
-        regex: openInterval, replace: ']$1' + sep + '$3[' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
-        regex: closedInterval, replace: '[$1' + sep + '$3]' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
-        regex: leftClosedInterval, replace: '[$1' + sep + '$3[' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
-        regex: rightClosedInterval, replace: ']$1' + sep + '$3]' },
+        regex: openInterval, replace: '$1]$2' + sep + '$4$5[' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+        regex: closedInterval, replace: '$1[$2' + sep + '$4$5]' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+        regex: leftClosedInterval, replace: '$1[$2' + sep + '$4$5[' }, { langs: MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS,
+        regex: rightClosedInterval, replace: '$1]$2' + sep + '$4$5]' },
     // closed intervals with angle brackets
     // We cannot use \langle|\rangle because of the linter
     // so we insert equivalent unicode chars directly.
     // U+27E8 | ⟨ | \xe2\x9f\xa8 | MATHEMATICAL LEFT ANGLE BRACKET
     // U+27E9 | ⟩ | \xe2\x9f\xa9 | MATHEMATICAL RIGHT ANGLE BRACKET
     { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-        regex: openInterval, replace: '($1' + sep + '$3)' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-        regex: closedInterval, replace: '⟨$1' + sep + '$3⟩' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-        regex: leftClosedInterval, replace: '⟨$1' + sep + '$3)' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
-        regex: rightClosedInterval, replace: '($1' + sep + '$3⟩' }];
+        regex: openInterval, replace: '$1($2' + sep + '$4$5)' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+        regex: closedInterval, replace: '$1⟨$2' + sep + '$4$5⟩' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+        regex: leftClosedInterval, replace: '$1⟨$2' + sep + '$4$5)' }, { langs: MATH_RULES_LOCALES.CLOSED_INT_AS_ANGLE_BRACKETS,
+        regex: rightClosedInterval, replace: '$1($2' + sep + '$4$5⟩' }];
 
     intervalTranslations.forEach(function (el) {
         if (el.langs.includes(lang)) {
@@ -652,7 +682,7 @@ function translateIntervals(math, template, lang) {
     }
 
     // The only thing we translate here is the separator!
-    var separatorTranslations = [{ regex: openInterval, replace: '($1' + sep + '$3)' }, { regex: closedInterval, replace: '[$1' + sep + '$3]' }, { regex: leftClosedInterval, replace: '[$1' + sep + '$3)' }, { regex: rightClosedInterval, replace: '($1' + sep + '$3]' }];
+    var separatorTranslations = [{ regex: openInterval, replace: '$1($2' + sep + '$4$5)' }, { regex: closedInterval, replace: '$1[$2' + sep + '$4$5]' }, { regex: leftClosedInterval, replace: '$1[$2' + sep + '$4$5)' }, { regex: rightClosedInterval, replace: '$1($2' + sep + '$4$5]' }];
 
     separatorTranslations.forEach(function (el) {
         math = math.replace(el.regex, el.replace);
@@ -681,44 +711,44 @@ function translateCoordinatesOrOpenIntervals(math, template, lang) {
         return math;
     }
     var orderedPairUS = getOrderedPairRegexString('en');
-    var coordsOrOpenIntervalUS = new RegExp('\\(' + orderedPairUS + '\\)', 'g');
+    var coordsOrOpenIntervalUS = new RegExp(wrapParens(orderedPairUS, '(', ')', true), 'g');
 
     // First look into the English string
-    var match = math.match(coordsOrOpenIntervalUS);
-    if (!match) {
+    if (!coordsOrOpenIntervalUS.test(math)) {
         return math;
     }
     // Now we know that the English string contains coordinates or intervals
-    // Let's detect them in the template, if we fail,
-    // we return prematurely
+    // Let's detect them in the template.
+    // If we fail, we return prematurely.
     var orderedPair = getOrderedPairRegexString(lang);
-    var coordsOrOpenInterval = new RegExp('([[(\\]])' + orderedPair + '([[)\\]])');
-    match = template.match(coordsOrOpenInterval);
+    var coordsOrOpenInterval = new RegExp('(?:\\\\left)?([[(\\]])' + orderedPair + '(?:\\\\right)?([[)\\]])');
+    var match = template.match(coordsOrOpenInterval);
     if (!match || match.length !== 6) {
         return math;
     }
 
-    var left = match[1];
+    var leftParen = match[1];
     var sep = match[3];
-    var right = match[5];
+    var rightParen = match[5];
 
     // Verify that left and right parentheses|brackets make sense
     // for a given language
-    switch (left) {
+    switch (leftParen) {
         case '[':
-            if (right !== ']' || !MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang)) return math;
+            if (rightParen !== ']' || !MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang)) return math;
             break;
         case ']':
-            if (right !== '[' || !MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang)) return math;
+            if (rightParen !== '[' || !MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang)) return math;
             break;
         case '(':
-            if (right !== ')') return math;
+            if (rightParen !== ')') return math;
             break;
         default:
             return math;
     }
 
-    var replace = left + '$1' + sep + '$3' + right;
+    // $1 and $4 refer to the optional \left and \right LaTeX commands
+    var replace = '$1' + leftParen + '$2' + sep + '$4$5' + rightParen;
 
     return math.replace(coordsOrOpenIntervalUS, replace);
 }

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -1103,6 +1103,33 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
             assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
         });
 
+    it('should handle complicated coordinates', function() {
+        const lang = 'cs';
+        assert(MATH_RULES_LOCALES.COORDS_AS_BRACKETS.includes(lang));
+        assert(MATH_RULES_LOCALES.DECIMAL_COMMA.includes(lang));
+
+        const allItems = [
+            {englishStr:
+                'maximum $\\left(-3\\pi,7\\right)$ midline $(-2.75\\pi,4)$',
+            translatedStr:
+                'max $\\left[-3\\pi;7\\right]$ mid $[-2{,}75\\pi;4]$',
+            },
+        ];
+
+        const itemsToTranslate = [
+            {englishStr:
+                'maximum $\\left(\\dfrac{3}{4}\\pi,1\\right)$ ' +
+                'midline $(-0.5\\pi,-2)$',
+            translatedStr: ''},
+        ];
+
+        const translatedStrs = [
+            'max $\\left[\\dfrac{3}{4}\\pi;1\\right]$ mid $[-0{,}5\\pi;-2]$',
+        ];
+
+        assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
+    });
+
     it('should translate open intervals according to a template', function() {
         const lang = 'fr';
         assert(MATH_RULES_LOCALES.OPEN_INT_AS_BRACKETS.includes(lang));


### PR DESCRIPTION
**Summary**
Arguments inside coordinates/intervals can be more complicated
so I expanded the regexes to handle several more cases:

1. \\left( \\right) notation for parentheses
(e.g. https://crowdin.com/translate/khanacademy/26329/enus-lol#3066988)
2. \\pi as an argument
3. \\frac{}{} as an argument
(e.g. https://crowdin.com/translate/khanacademy/26329/enus-lol#3066977)

I added new tests that hopefully make it clear
what we're trying to achieve.

**Test Plan**
 - New tests should pass
 - Test in exercise
   https://www.khanacademy.org/translations/edit/lol/e/graphs-of-trigonometric-functions/tree/upstream/by-pattern
   Patterns 22, 27, 28

