### PR TITLE
More refinements for coordinates/intervals translations

### DIFF
--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -50,10 +50,20 @@ var MATH_RULES_LOCALES = {
   // Number formats
   THOUSAND_SEP_AS_THIN_SPACE: ['az', 'bg', 'cs', 'de', 'fr', 'hu', 'it', 'ka', 'km', 'ky', 'lv', 'nb', 'nl', 'pl', 'pt-pt', 'ro', 'sv', 'uk'],
   THOUSAND_SEP_AS_DOT: ['da', 'el', 'id', 'pt', 'sr', 'tr', 'vi'],
-  NO_THOUSAND_SEP: ['hy', 'kk', 'ko', 'ps'],
+  NO_THOUSAND_SEP: ['hy', 'kk', 'ko'],
   DECIMAL_COMMA: ['az', 'bg', 'cs', 'da', 'de', 'el', 'fr', 'hu', 'hy', 'id', 'it', 'ka', 'kk', 'ky', 'lv', 'nb', 'nl', 'pl', 'pt', 'pt-pt', 'ro', 'ru', 'sr', 'sv', 'tr', 'vi'],
-  ARABIC_COMMA: ['ps'],
-  PERSO_ARABIC_NUMERALS: ['ps'],
+  // Pashto team would like to use both perso-arabic numerals for Early Math
+  // and western digits for more advanced math courses.
+  // Unfortunately, we don't support this at the moment,
+  // since strings are often shared between different exercises.
+  // For the time being, Pashto will use the western digits
+  // NOTE(danielhollas): I did not want to delete the whole code
+  // in case it's usefuly in the future so I simply removed 'ps'
+  // from the locale lists.
+  //PERSO_ARABIC_NUMERALS: ['ps'],
+  //ARABIC_COMMA: ['ps'],
+  ARABIC_COMMA: ['fake-lang'],
+  PERSO_ARABIC_NUMERALS: ['fake-lang'],
   // Notations for repeating decimals
   // 1 / 3 = 0.\overline{3} -> 0.\dot{3}
   // 1 / 7 = 0.\overline{142857} -> 0.\dot{1}4285\dot{7}

--- a/lib/math-translator.js
+++ b/lib/math-translator.js
@@ -425,6 +425,20 @@ function maybeTranslateMath(math, template, lang) {
 
 var KATEX_BASE_COLORS = ['blue', 'gold', 'gray', 'mint', 'green', 'red', 'maroon', 'orange', 'pink', 'purple', 'teal', 'kaBlue', 'kaGreen'];
 /**
+ * Return regex string matching numerals for a given languages
+ *
+ * @param {string} lang The KA locale
+ * @returns {string} String to be passed into RegExp constructor.
+ */
+
+function getDigitsRegexString(lang) {
+  if (MATH_RULES_LOCALES.PERSO_ARABIC_NUMERALS.includes(lang)) {
+    return '[۱۲۳۴۵۶۷۸۹۰]';
+  } else {
+    return '[0-9]';
+  }
+}
+/**
  * Construct regular expression to match decimal numbers for a given lang,
  * possibly wrapped in TeX commands.
  *
@@ -442,6 +456,7 @@ var KATEX_BASE_COLORS = ['blue', 'gold', 'gray', 'mint', 'green', 'red', 'maroon
  * @returns {string} String to be passed into RegExp constructor.
  */
 
+
 function getDecNumberRegexString(lang, capture) {
   if (capture === void 0) {
     capture = true;
@@ -455,19 +470,17 @@ function getDecNumberRegexString(lang, capture) {
   // from KaTeX. This will form a superset of actually defined colors,
   // but that hardly matters here and is more future-proof if new colors
   // were defined at some point
-  var katexColorMacros = KATEX_BASE_COLORS.join('|'); // TODO: Generalize this to other numeral systems, such as perso-arabic
-  // i.e. in regexes instead of [0-9] we need [[۱۲۳۴۵۶۷۸۹۰]
-  // We need a helper function to return a number regex, similarly to
-  // getEscapedDecimalSeparator()
+  var katexColorMacros = KATEX_BASE_COLORS.join('|'); // returns '[0-9]' for most languages
 
-  var integerPart = "-?[0-9]+|-?\\\\(?:" + katexColorMacros + ")[A-Z]?\\{-?[0-9]+\\}"; // Decimal part is different from integer part
+  var dig = getDigitsRegexString(lang);
+  var integerPart = "-?" + dig + "+|-?\\\\(?:" + katexColorMacros + ")[A-Z]?\\{-?" + dig + "+\\}"; // Decimal part is different from integer part
   // because it can contain \\overline
   // TODO: Some langs do not use \\overline, but \\dot
 
-  var decPart = "[0-9]+|\\\\(?:overline|" + katexColorMacros + ")[A-Z]?\\{[0-9]+\\}";
+  var decPart = dig + "+|\\\\(?:overline|" + katexColorMacros + ")[A-Z]?\\{" + dig + "+\\}";
   var sep = getEscapedDecimalSeparator(lang); // This part matches strings like `\\green{1.2}`
 
-  var wrappedDecimal = "\\\\(?:" + katexColorMacros + ")[A-Z]?\\{-?[0-9]+" + sep + "[0-9]+\\}"; // Wrapped decimal is not needed if we capture integer and decimal part
+  var wrappedDecimal = "\\\\(?:" + katexColorMacros + ")[A-Z]?\\{-?" + dig + "+" + sep + dig + "+\\}"; // Wrapped decimal is not needed if we capture integer and decimal part
   // because in that case we do not care that the decimal number
   // is wrapped as a whole
 
@@ -510,15 +523,17 @@ function getEscapedDecimalSeparator(lang) {
 
 
 function getOrderedPairRegexString(lang) {
-  var katexColorMacros = "\\\\(?:" + KATEX_BASE_COLORS.join('|') + ")[A-Z]?"; // Assuming single-letter variables (or \pi) and numbers below 1000
+  var katexColorMacros = "\\\\(?:" + KATEX_BASE_COLORS.join('|') + ")[A-Z]?";
+  var dig = getDigitsRegexString(lang); // Assuming single-letter variables (or \pi) and numbers below 1000
   // (without thousand separator) or combinations, such as '2\\pi' or '2.1b'
 
-  var integer = "-?[0-9]+|-?" + katexColorMacros + "\\{-?[0-9]+\\}|-?" + katexColorMacros + "[0-9]";
-  var variable = "\\\\pi|[a-z]|" + katexColorMacros + "\\{[a-z]\\}";
+  var integer = "-?(?:" + dig + "+|" + (katexColorMacros + "\\{-?" + dig + "+\\}|") + ("" + katexColorMacros + dig + ")");
+  var variable = "-?(?:\\\\pi|[a-z]|" + katexColorMacros + "\\{[a-z]\\})";
   var decimal = getDecNumberRegexString(lang,
   /* don't include capture groups */
-  false);
-  var fracArgument = "(?:" + variable + "|" + integer + ")"; // Match '\\frac{1}{2}'
+  false); // Match 'a', '2' or '2a'
+
+  var fracArgument = "(?:" + variable + "|(?:" + integer + ")(?:" + variable + ")?)"; // Match '\\frac{1}{2}' or `\\frac{3\\pi}{2}
 
   var frac = "-?\\\\d?frac\\{" + fracArgument + "\\}\\{" + fracArgument + "\\}"; // Match '\frac{3}{4}\\pi'
 

--- a/src/math-translator.js
+++ b/src/math-translator.js
@@ -13,12 +13,22 @@ const MATH_RULES_LOCALES = {
     THOUSAND_SEP_AS_THIN_SPACE: ['az', 'bg', 'cs', 'de', 'fr', 'hu', 'it', 'ka',
         'km', 'ky', 'lv', 'nb', 'nl', 'pl', 'pt-pt', 'ro', 'sv', 'uk'],
     THOUSAND_SEP_AS_DOT: ['da', 'el', 'id', 'pt', 'sr', 'tr', 'vi'],
-    NO_THOUSAND_SEP: ['hy', 'kk', 'ko', 'ps' ],
+    NO_THOUSAND_SEP: ['hy', 'kk', 'ko'],
     DECIMAL_COMMA: ['az', 'bg', 'cs', 'da', 'de', 'el', 'fr', 'hu', 'hy', 'id',
         'it', 'ka', 'kk', 'ky', 'lv', 'nb', 'nl', 'pl', 'pt', 'pt-pt', 'ro',
         'ru', 'sr', 'sv', 'tr', 'vi'],
-    ARABIC_COMMA: ['ps'],
-    PERSO_ARABIC_NUMERALS: ['ps'],
+    // Pashto team would like to use both perso-arabic numerals for Early Math
+    // and western digits for more advanced math courses.
+    // Unfortunately, we don't support this at the moment,
+    // since strings are often shared between different exercises.
+    // For the time being, Pashto will use the western digits
+    // NOTE(danielhollas): I did not want to delete the whole code
+    // in case it's usefuly in the future so I simply removed 'ps'
+    // from the locale lists.
+    //PERSO_ARABIC_NUMERALS: ['ps'],
+    //ARABIC_COMMA: ['ps'],
+    ARABIC_COMMA: ['fake-lang'],
+    PERSO_ARABIC_NUMERALS: ['fake-lang'],
     // Notations for repeating decimals
     // 1 / 3 = 0.\overline{3} -> 0.\dot{3}
     // 1 / 7 = 0.\overline{142857} -> 0.\dot{1}4285\dot{7}

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -1165,9 +1165,7 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
 
-    // TODO(danielhollas): Make this test work. :-)
-    // We need to generalize our regexes to support perso-arabic numerals
-    it.skip('should handle perso-arabic numerals in coordinates', function() {
+    it('should handle perso-arabic numerals in coordinates', function() {
         const lang = 'ps';
         assert(MATH_RULES_LOCALES.ARABIC_COMMA.includes(lang));
 

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -999,11 +999,10 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
      * the code in `getSuggestionGroups()` creates the template from the first
      * translatedStr and skips the rest.
      */
-    /*
-    it('should translate math-only strings from multiple templates',
-        function() {
-        // Lang 'id' is in both MAYBE_TIMES_AS_CDOT and MAYBE_DIV_AS_COLON
+    it.skip('should handle notation from from multiple templates', function() {
         const lang = 'id';
+        assert(MATH_RULES_LOCALES.MAYBE_TIMES_AS_CDOT.includes(lang));
+        assert(MATH_RULES_LOCALES.MAYBE_DIV_AS_COLON.includes(lang));
         const allItems = [
             {englishStr: '$6 \\div y$', translatedStr: '$6 \\mathbin{:} y$'},
             {englishStr: '$3 \\times x$', translatedStr: '$3 \\cdot x$'},
@@ -1016,7 +1015,6 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
-    */
 
     it('should translate closed intervals in math-only strings', function() {
         const lang = 'fr';
@@ -1165,9 +1163,13 @@ describe('TranslationAssistant (maybe-math-translate)', function() {
         assertSuggestions(allItems, itemsToTranslate, translatedStrs, lang);
     });
 
+    // NOTE(danielhollas): Pashto team will use the western digits for now,
+    // see comment in scr/math_translator.js. Hence, we use 'fake-lang'
+    // to keep our test coverage.
     it('should handle perso-arabic numerals in coordinates', function() {
-        const lang = 'ps';
+        const lang = 'fake-lang';
         assert(MATH_RULES_LOCALES.ARABIC_COMMA.includes(lang));
+        assert(MATH_RULES_LOCALES.PERSO_ARABIC_NUMERALS.includes(lang));
 
         const allItems = [
             {englishStr: 'Coordinates $(0,3.\\overline{3}) (\\blueD{-1},0)$',

--- a/tests/math_translator_spec.js
+++ b/tests/math_translator_spec.js
@@ -748,6 +748,9 @@ describe('detectClosedIntervals', function() {
         englishMath = '\\left(\\frac{3}{4}\\pi,5\\right]';
         assert(detectClosedInterval(englishMath));
 
+        englishMath = '\\left(\\frac{3\\pi}{2},5\\right]';
+        assert(detectClosedInterval(englishMath));
+
         // Sanity check, should not allow empty parameter
         // (even though it's a valid LaTeX
         englishMath = '(\\frac{}{4},5]';
@@ -758,7 +761,7 @@ describe('detectClosedIntervals', function() {
         let englishMath = '(a,b]';
         assert(detectClosedInterval(englishMath));
 
-        englishMath = '[a,2)';
+        englishMath = '[-a,2)';
         assert(detectClosedInterval(englishMath));
     });
 });

--- a/tests/math_translator_spec.js
+++ b/tests/math_translator_spec.js
@@ -163,13 +163,16 @@ describe('MathTranslator (translateMath)', function() {
         });
     });
 
-    it('should use arabic decimal comma and no thousand separator for pashto',
-        function() {
-            const englishStr = '1{,}234{,}567.890';
-            const translatedStr = '۱۲۳۴۵۶۷{،}۸۹۰';
-            const outputStr = translateMath(englishStr, '', 'ps');
+    // Pashto is in fact using western-style digits for now,
+    // see comment in math_translator.js
+    it('should handle arabic comma', function() {
+        const englishStr = '567.890';
+        const translatedStr = '۵۶۷{،}۸۹۰';
+        MATH_RULES_LOCALES.ARABIC_COMMA.forEach(function(locale) {
+            const outputStr = translateMath(englishStr, '', locale);
             assert.equal(outputStr, translatedStr);
         });
+    });
 
     it('should translate repeating decimal numbers', function() {
         // We cannot iterate over all locales from DECIMAL_COMMA


### PR DESCRIPTION
Closes #41.

**Test Plan:**
  - New tests passing.
  - ST should work for all strings in
    'e/graphs-of-trigonometric-functions'
  - Spefically strings mentioned in #41 

**EDIT**: I have verified the test plan locally.

I have also added full support for non-western digits.
However, after discussing with the Pashto team,
they decided to use the western-style digits for now.

Ideally, they would want to use perso-arabic numerals
for Early Math, and western style for higher math,
but we can't support that at the moment since strings
are often shared between exercises.

I didn't delete the code for handling non-western numerals
as it may be useful in the future once we have full support
for RTL languages and more such langugages start translating
exercises.

PS: Please do not squash the commits upon merging
to preserve this change separately in the git history.