### PR TITLE
Match trailing newlines in suggestions and englishStr.

### DIFF
--- a/lib/translation-assistant.js
+++ b/lib/translation-assistant.js
@@ -416,6 +416,27 @@ function rtrim(str) {
   return str.replace(/\s+$/g, '');
 }
 /**
+ * Count trailing newlines in a string.
+ *
+ * @param {string} str An input string.
+ * @returns {number} The string with no trailing whitespace.
+ */
+
+
+function countTrailingNewlines(str) {
+  var count = 0;
+
+  for (var i = str.length; i > 0; i--) {
+    if (str[i - 1] === '\n') {
+      count++;
+    } else {
+      break;
+    }
+  }
+
+  return count;
+}
+/**
  * Escape any string to create regular expression
  *
  * See: https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/
@@ -474,6 +495,7 @@ function replaceTextInMath(englishMath, dict) {
 
 
 function populateTemplate(template, englishStr, lang) {
+  var trailingNewlinesCount = countTrailingNewlines(englishStr);
   englishStr = rtrim(englishStr);
   var englishLines = englishStr.split(LINE_BREAK);
 
@@ -532,7 +554,7 @@ function populateTemplate(template, englishStr, lang) {
   }).map(function (math) {
     return replaceTextInMath(math, template.mathDictionary);
   });
-  return englishLines.map(function (englishLine, index) {
+  var suggestion = englishLines.map(function (englishLine, index) {
     var templateLine = template.lines[index];
     return templateLine.replace(/__MATH__/g, function () {
       return maths[template.mathMapping.englishToTranslated[mathIndex++]];
@@ -543,7 +565,16 @@ function populateTemplate(template, englishStr, lang) {
     }).replace(/__WIDGET__/g, function () {
       return widgets[template.widgetMapping[widgetIndex++]];
     });
-  }).join(LINE_BREAK);
+  }).join(LINE_BREAK); // Crowdin blocks translations that are missing trailing newlines
+  // so we add them back.
+
+  if (trailingNewlinesCount > 0) {
+    for (var i = 0; i < trailingNewlinesCount; i++) {
+      suggestion += '\n';
+    }
+  }
+
+  return suggestion;
 }
 /**
  * Provides suggestions for one or more strings from one or more groups of
@@ -616,6 +647,9 @@ var TranslationAssistant = /*#__PURE__*/function () {
         lang = this.lang;
     return itemsToTranslate.map(function (item) {
       var englishStr = rtrim(_this.getEnglishStr(item));
+
+      var englishStrNonTrim = _this.getEnglishStr(item);
+
       var normalStr = stringToGroupKey(englishStr);
       var normalObj = JSON.parse(normalStr); // Return items that are only a graphie, an image, or a widget
       // unchanged. Presumably, even if the translator changed
@@ -637,7 +671,7 @@ var TranslationAssistant = /*#__PURE__*/function () {
         }
 
         if (template) {
-          var translatedStr = populateTemplate(template, englishStr, lang);
+          var translatedStr = populateTemplate(template, englishStrNonTrim, lang);
           return [item, translatedStr];
         }
       } // Translate items that are only math even if there's no template.

--- a/tests/assistant_spec.js
+++ b/tests/assistant_spec.js
@@ -378,7 +378,10 @@ describe('TranslationAssistant (math)', function() {
         assertSuggestions(allItems, itemsToTranslate, translatedStrs);
     });
 
-    it('should handle trailing newline in englishStr', function() {
+    it('should handle missing trailing newline in translatedStr', function() {
+        // NOTE(danielhollas): Crowdin started blocking translations with
+        // mismatching trailing newlines so this example should not happen
+        // in practice anymore.
         assertSuggestions([{
             englishStr:
                 'simplify $2x = 4$, answer $x = 2$\n\n',
@@ -386,29 +389,35 @@ describe('TranslationAssistant (math)', function() {
                 'simplifyz $2x = 4$, answerz $x = 2$',
         }], [{
             englishStr:
-                'simplify $3x = 9$, answer $x = 3$\n\n',
+                'simplify $3x = 9$, answer $x = 3$ \n\n',
             translatedStr: '',
         }], [
-            'simplifyz $3x = 9$, answerz $x = 3$',
+            'simplifyz $3x = 9$, answerz $x = 3$\n\n',
         ]);
     });
 
     it('should handle trailing newline in translatedStr', function() {
         const allItems = [{
             englishStr: 'simplify $2x = 4$, answer $x = 2$',
-            translatedStr:'simplifyz $2x = 4$, answerz $x = 2$\n\n',
+            translatedStr:'simplifyz $2x = 4$, answerz $x = 2$ \n ',
         }];
         const itemsToTranslate = [{
             englishStr: 'simplify $3x = 9$, answer $x = 3$',
+            translatedStr: '',
+        }, {
+            englishStr: 'simplify $3x = 9$, answer $x = 3$\n\n',
             translatedStr: '',
         }];
         // We trim trailing newlines in the translated string inside
         // createTemplate and we do the same for the English string inside
         // populateTemplate in order to match the string & template when
-        // suggesting translations. That is why we have no trailing newlines
-        // in translatedStrs here, since the translated string created from the
-        // template will not have any trailing newlines.
-        const translatedStrs = ['simplifyz $3x = 9$, answerz $x = 3$'];
+        // suggesting translations. However, we always then post-process
+        // the suggested string to match the number of trailing newlines
+        // in the English string.
+        const translatedStrs = [
+            'simplifyz $3x = 9$, answerz $x = 3$',
+            'simplifyz $3x = 9$, answerz $x = 3$\n\n',
+        ];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs);
     });
@@ -420,14 +429,19 @@ describe('TranslationAssistant (math)', function() {
         }];
         // We trim trailing newlines in order to match the English string to the
         // template for suggesting a translation.
+        // However, in suggested translation we always match the number
+        // of trailing newlines in the English string.
         const itemsToTranslate = [{
-            englishStr: 'simplify $3x = 9$, answer $x = 3$\n\n',
+            englishStr: 'simplify $3x = 9$, answer $x = 3$ \n\n',
+            translatedStr: '',
+        }, {
+            englishStr: 'simplify $3x = 9$, answer $x = 3$\n',
             translatedStr: '',
         }];
-        // That is why we have no trailing newlines in translatedStrs here,
-        // since the translated string created from the template will not have
-        // any trailing newlines.
-        const translatedStrs = ['simplifyz $3x = 9$, answerz $x = 3$'];
+        const translatedStrs = [
+            'simplifyz $3x = 9$, answerz $x = 3$\n\n',
+            'simplifyz $3x = 9$, answerz $x = 3$\n',
+        ];
 
         assertSuggestions(allItems, itemsToTranslate, translatedStrs);
     });


### PR DESCRIPTION
Crowdin started blocking translations in which the number
of trailing newlines does not match the original string.
Up until now we've always stripped all trailing whitespace
so in some cases ST suggestions were being blocked by Crowdin.

In this fix, we append trailing newlines in the suggested
translation based on the original English string.
Note that we still strip all other whitespace. (should we?)

Issue: https://khanacademy.atlassian.net/browse/IC-796

Test plan:
  - ST should work for pattern 1 in exercise
https://www.khanacademy.org/translations/edit/lol/math/trigonometry/unit-circle-trig-func/graphing-sinusoids/e/graphs_of_sine_and_cosine/tree/upstream/by-pattern
(for string like [this one](https://crowdin.com/translate/khanacademy/43692/enus-lol#6902014))